### PR TITLE
docs: record API-contract direction + mobile/AI roadmap

### DIFF
--- a/docs/architecture/decisions/ADR-INDEX.md
+++ b/docs/architecture/decisions/ADR-INDEX.md
@@ -28,6 +28,8 @@ Status labels: **Proposed** | **Accepted** | **Rejected** | **Superseded**
 |-------|---------------|-------|
 | ADR-002 | Production DB migration & backfill strategy | `prisma migrate` vs `db push`; backfilling owner columns (depends on ADR-001) |
 | ADR-003 | Curated library & copy-on-pull | Read-only team-published source lists; deep-copy into user account on pull; `sourceListId` provenance; **no** user-publishing (UGC deferred per Decision 1). Depends on ADR-001 |
+| ADR-004 | API contract & versioning for multiple clients | Roadmap adds native Android/iOS, making `/api/v1` multi-client. Standardize the contract on Zod as single source (#44); decide OpenAPI + client codegen; define an API version/deprecation policy (mobile clients can't deploy in lockstep with the backend) |
+| ADR-005 | AI-assisted list generation | User enters a topic → an LLM generates the word/clue list. Provider integration + key management, prompt (`sample-puzzles/ai-list-generation-prompt.md`), cost/rate controls, and **AI-content safety/moderation for the minors audience** (Decision 1). The generated list is non-deterministic; puzzle generation from a list stays seeded (#35) |
 
 ---
 
@@ -37,6 +39,8 @@ Topics that influence architecture but do not yet have ADRs:
 
 - JSON-as-`String` columns (`Puzzle.grid/numbering/settings`, `List.tags`, `Solve.state`) vs Prisma `Json` type — revisit if queryability/validation is needed.
 - Anonymous vs authenticated solves: `Solve.userId` is nullable with `@@unique([puzzleId, userId])` — decide whether anonymous solves are supported.
+- API contract for multiple clients (web today; native Android/iOS planned) — single Zod source now (#44); OpenAPI/codegen + versioning policy to be decided in ADR-004.
+- AI-content safety: AI-generated lists shown to a minors audience (Decision 1) need a moderation/safety review — to be scoped in ADR-005.
 
 ---
 

--- a/docs/compliance/COMPLIANCE_REGISTER.md
+++ b/docs/compliance/COMPLIANCE_REGISTER.md
@@ -35,10 +35,10 @@ owns it, and whether it's met.
 
 | Trigger | Verdict | Reasoning |
 |---|---|---|
-| Mobile store requirements (Apple/Google) | ➖ N/A | No mobile binary — web only. Revisit if a native/PWA-store build ships. |
+| Mobile store requirements (Apple/Google) | ⚠ Planned trigger | No mobile binary today, but **native Android + iOS apps are a stated roadmap goal**. Apple App Store / Google Play obligations (privacy nutrition labels / Data safety form, account-deletion requirement, age ratings, and the **minors tier** per Decision 1) **will fire** when a native build ships. Revisit before mobile work begins — see ADR-004 (planned). |
 | Messaging / UGC safety (report/block/moderation, DSA/OSA) | ➖ N/A | No user-to-user content. Sharing, collaboration, public links, and guest play are explicitly out of scope in the spec. **Revisit immediately if "shareable puzzles / public sharing links" (a stated stretch goal) is built** — that would fire UGC + the minors tier hard. |
 | Payments / PCI DSS | ➖ N/A | No monetization. |
-| OpenAPI 3.x spec | ➖ Optional | The `/api/v1` API is **first-party** (consumed only by CrossWise's own frontend; typed via `src/types/api.ts`). "Where it makes sense" ⇒ OpenAPI is low-value here. Promote to required only if the API is opened to third parties. |
+| OpenAPI 3.x spec | ➖ Optional (reconsider for mobile) | The `/api/v1` API is **first-party** and today consumed only by the web frontend (typed via `src/types/api.ts`) ⇒ OpenAPI is currently low-value. **Reconsideration triggers:** (a) opening the API to third parties, or (b) the planned **native mobile clients** (Android/iOS) — multiple first-party clients that can't share TS types make a language-neutral contract worthwhile. Intended path: standardize the contract on Zod (#44), then generate OpenAPI + client codegen from those schemas if promoted. See ADR-004 (planned). |
 | Tracking / App Tracking Transparency | ➖ N/A | No analytics/tracking SDKs in the codebase. |
 
 ## Decisions & scoping notes


### PR DESCRIPTION
Captures the stated roadmap goals — **native Android/iOS apps** and **AI-assisted list generation** — in the governance docs so they steer current decisions (especially the API contract). Docs-only.

## Changes
- **COMPLIANCE_REGISTER**: mobile-store row → "planned trigger" (App Store/Play privacy labels, account-deletion, age ratings, minors tier per Decision 1 fire when a native build ships). OpenAPI row reframed: native mobile = a reconsideration trigger; the intended path is to standardize the contract on Zod (#44) and generate OpenAPI/codegen from those schemas if promoted.
- **ADR-INDEX**: planned **ADR-004** (API contract & versioning for multiple clients) and **ADR-005** (AI-assisted list generation, incl. minors-audience content safety), plus matching open decision gaps.

## Related
- #44 — standardize the `/api/v1` contract on Zod (single source of truth, kill the `difficulty` type drift).
- A `docs/decision_log.md` "Decision 2" capturing the roadmap direction is drafted separately and pending owner approval before recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)