### PR TITLE
refactor(api): derive API contract types from Zod (single source of truth)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Use these as completion gates:
 - Verify security/authorization boundaries with negative-path checks on every feature.
 - Loading/empty/error states required for all data-driven views (if there's a UI).
 - Destructive actions require explicit confirmation.
+- **API contract is Zod-first**: request/response shapes for `src/app/api/v1` are defined as Zod schemas in `src/lib/validation.ts` (the single source of truth); TypeScript types are derived from them via `z.input`/`z.infer` in `src/types/api.ts`. Do not hand-write request interfaces — they drift. (See #44; OpenAPI/codegen for future clients is ADR-004.)
 - **CHANGELOG discipline**: every PR that ships user-visible behavior adds a one-line entry under `## [Unreleased]` in `CHANGELOG.md` in the same PR. Skip only for purely internal work. Versions bump only at release time, in lockstep — use `/release` (wraps `ai/scripts/release.sh`), don't hand-edit version files. Full rules: `ai/STANDARDS/VERSIONING_AND_CHANGELOG_STANDARD.md`.
 
 ## Anti-Drift Rules

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -108,4 +108,25 @@ describe('validation helpers', () => {
     expect(result.valid).toBe(false)
     expect(result.issues).toContain('Answer too long (maximum 20 letters)')
   })
+
+  it('accepts both numeric (1-5) and string difficulty on import, but rejects out-of-range values', () => {
+    const base = {
+      topic: 'Animals',
+      name: 'Mammals',
+      items: [
+        { answer: 'otter', clue: 'Playful river mammal', difficulty: 3 },
+        { answer: 'Sealion', clue: 'Barks loudly on the shore', difficulty: 'HARD' },
+        { answer: 'Fennec', clue: 'Desert fox with big ears' },
+        { answer: 'Badger', clue: 'Builds complex burrows underground' },
+        { answer: 'Panda', clue: 'Eats mostly bamboo', difficulty: 'EASY' },
+      ],
+    }
+    expect(validateListJSON(base).success).toBe(true)
+
+    const bad = {
+      ...base,
+      items: [{ ...base.items[0], difficulty: 6 }, ...base.items.slice(1)],
+    }
+    expect(validateListJSON(bad).success).toBe(false)
+  })
 })

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -37,7 +37,7 @@ const DifficultyInputSchema = z.union([
   z.literal('HARD'),
 ])
 
-const ListItemInputSchema = z.object({
+export const ListItemInputSchema = z.object({
   answer: z
     .string()
     .min(2, 'Answer must be at least 2 characters')

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,49 +1,49 @@
+/**
+ * API contract types for `/api/v1`.
+ *
+ * SINGLE SOURCE OF TRUTH: request shapes are **derived** from the Zod schemas in
+ * `src/lib/validation.ts` — do not hand-write request interfaces here. Define a new
+ * endpoint's contract as a Zod schema in `validation.ts`, then derive its type below.
+ * This keeps runtime validation and compile-time types from drifting (issue #44).
+ *
+ * Note on `z.input` vs `z.infer`: request types use `z.input` (the shape the *client
+ * sends*, before defaults/transforms run), so optional-with-default fields stay optional.
+ *
+ * Response types have no schema yet and are declared directly; give them schemas (and
+ * derive their types the same way) when response validation or OpenAPI generation is
+ * introduced — see ADR-004 (planned).
+ */
+import { z } from 'zod'
+import {
+  CreateTopicSchema,
+  CreateListSchema,
+  ListItemInputSchema,
+  GeneratePuzzleSchema,
+  ImportListSchema,
+  UpdateSolveStateSchema,
+  RegisterSchema,
+  LoginSchema,
+} from '@/lib/validation'
 import type { CrosswordGrid, CrosswordNumbering, PuzzleSettings } from '@/types/crossword'
 
-// API request/response types
-export interface CreateTopicRequest {
-  name: string
-  description?: string
-  color?: string
-  icon?: string
-}
+// --- Request types (derived from Zod schemas) ---
 
-export interface CreateListRequest {
-  topicId: string
-  name: string
-  items: ListItemInput[]
-}
+export type CreateTopicRequest = z.input<typeof CreateTopicSchema>
+export type CreateListRequest = z.input<typeof CreateListSchema>
+export type ListItemInput = z.input<typeof ListItemInputSchema>
+export type GeneratePuzzleRequest = z.input<typeof GeneratePuzzleSchema>
+export type ImportListRequest = z.input<typeof ImportListSchema>
+export type UpdateSolveStateRequest = z.input<typeof UpdateSolveStateSchema>
+export type RegisterRequest = z.input<typeof RegisterSchema>
+export type LoginRequest = z.input<typeof LoginSchema>
 
-export interface ListItemInput {
-  answer: string
-  clue: string
-  note?: string
-  difficulty?: 'EASY' | 'MEDIUM' | 'HARD'
-}
-
-export interface GeneratePuzzleRequest {
-  listId: string
-  gridSize?: { rows?: number; cols?: number }
-  seed?: string
-}
+// --- Response types (no schema yet; declared directly) ---
 
 export interface GeneratePuzzleResponse {
   puzzleId: string
   grid: CrosswordGrid
   numbering: CrosswordNumbering
   settings: PuzzleSettings
-}
-
-export interface ImportListRequest {
-  topic: string
-  name: string
-  version?: number
-  items: {
-    answer: string
-    clue: string
-    note?: string
-    difficulty?: number
-  }[]
 }
 
 export interface ExportListResponse {
@@ -54,17 +54,13 @@ export interface ExportListResponse {
     answer: string
     clue: string
     note?: string
+    // Export emits numeric difficulty (1-3); persisted storage uses the EASY/MEDIUM/HARD enum.
     difficulty?: number
   }[]
 }
 
-export interface UpdateSolveStateRequest {
-  puzzleId: string
-  state: string // JSON stringified solve state
-  completed?: boolean
-}
+// --- Response envelope / error types ---
 
-// API error types
 export interface ApiError {
   message: string
   code?: string


### PR DESCRIPTION
Closes #44.

Makes the Zod schemas in `src/lib/validation.ts` the single source of truth for the `/api/v1` contract, and derives the types in `src/types/api.ts` from them (`z.input`) so runtime validation and compile-time types can't drift.

## Changes
- `src/types/api.ts` — request types are now `z.input<typeof Schema>` for every schema (CreateTopic, CreateList, ListItemInput, GeneratePuzzle, ImportList, UpdateSolveState, Register, Login). Response/envelope types stay declared until they get schemas.
- `src/lib/validation.ts` — export `ListItemInputSchema` for reuse.
- `CLAUDE.md` — record the **Zod-first API contract** convention.
- `validation.test.ts` — assert dual-format difficulty is accepted and out-of-range rejected.

## Two findings that shaped the implementation
1. **`src/types/api.ts` had zero importers** — the hand-rolled interfaces were unused, which is exactly why they drifted. They're now correct-by-construction and ready for real consumers (web hooks today, mobile codegen later per ADR-004).
2. **`difficulty` is intentionally dual-format**, not a bug: numeric **1–5** *or* `EASY/MEDIUM/HARD` on input, **enum** in storage, **numeric 1–3** on export (the sample JSONs and the AI prompt use 1–5). I therefore made the types *faithful to the schemas* rather than flattening to the enum — flattening would have broken the import format and changed export output. **The issue's "difficulty → enum everywhere" acceptance criterion is superseded by this** (noted on #44).

## Evidence
- `tsc --noEmit`: clean · `npm run build`: success · `npm test`: **109 passing** · lint: clean.
- No runtime behavior change (types only) → no CHANGELOG entry (purely internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)