### PR TITLE
fix(db): rewrite topic-ownership migration as expand/backfill/contract

### DIFF
--- a/prisma/migrations/20260625000000_add_topic_ownership/migration.sql
+++ b/prisma/migrations/20260625000000_add_topic_ownership/migration.sql
@@ -1,20 +1,30 @@
 -- Add per-user ownership to topics (ADR-001 / #34).
 --
--- STRATEGY: pre-launch reset (ADR-002). CrossWise has no real user data yet, so we do
--- NOT backfill existing topics. `ADD COLUMN "user_id" ... NOT NULL` below will fail on a
--- table that already contains rows — that is intentional. Apply this on a fresh database
--- (`prisma migrate deploy` on an empty DB) or reset an existing dev/preview DB with
--- `prisma migrate reset` (which replays all migrations and reseeds with ownership).
--- When real user data exists, supersede this with an expand/contract migration that
--- adds the column nullable, backfills an owner, then tightens to NOT NULL.
+-- STRATEGY: expand/backfill/contract (ADR-002). The original version of this migration
+-- assumed a pre-launch reset ("no real data yet") and added the column NOT NULL in one
+-- step; it failed on the Dev database (23502 — existing topics have no owner) because
+-- the DB already holds real accounts and content (#57). The failed attempt rolled back
+-- transactionally and was marked rolled back; this rewritten version was never
+-- successfully applied anywhere, so editing it in place is safe.
+--
+-- Existing un-owned topics are backfilled to the earliest-created user account (the
+-- instance owner). On a fresh/empty database the backfill is a no-op and the end state
+-- is identical. NOTE: a database that has topics but no users cannot satisfy the
+-- NOT NULL contract step — that state is unreachable through the app.
 
--- DropIndex
+-- Expand: add the column nullable
+ALTER TABLE "public"."topics" ADD COLUMN "user_id" TEXT;
+
+-- Backfill: assign pre-ownership topics to the earliest-created user account
+UPDATE "public"."topics"
+SET "user_id" = (SELECT "id" FROM "public"."users" ORDER BY "created_at" ASC LIMIT 1)
+WHERE "user_id" IS NULL;
+
+-- Contract: enforce ownership
+ALTER TABLE "public"."topics" ALTER COLUMN "user_id" SET NOT NULL;
+
+-- Topic names are now unique per user instead of globally
 DROP INDEX "public"."topics_name_key";
-
--- AlterTable
-ALTER TABLE "public"."topics" ADD COLUMN "user_id" TEXT NOT NULL;
-
--- CreateIndex
 CREATE UNIQUE INDEX "topics_user_id_name_key" ON "public"."topics"("user_id", "name");
 
 -- AddForeignKey


### PR DESCRIPTION
Fixes #57 — unblocks the migrate→deploy pipeline on main.

The first `migrate` run on main (after #49 + #48) failed applying `20260625000000_add_topic_ownership`: `ERROR: column "user_id" of relation "topics" contains null values (23502)`. The migration was written pre-launch-reset style, but the Dev DB already holds real data (2 accounts, 4 topics, 6 lists, 13 puzzles, solves) — a `migrate reset` would violate the no-data-loss non-negotiable, so this takes ADR-002's prescribed fallback for populated DBs instead: **expand/backfill/contract**.

- Add `user_id` nullable → backfill existing topics to the earliest-created user account (the instance owner) → `SET NOT NULL` → swap global-unique name for per-user unique, add FK. End state identical to the original migration; on a fresh DB the backfill no-ops.
- Editing the migration in place is safe: the original never applied successfully anywhere (the failed attempt rolled back transactionally — verified no schema residue).
- **Validated against the live DB in a `BEGIN…ROLLBACK` transaction**: applies cleanly, 4 topics backfilled to 1 owner, 0 unowned.

Deploy recovery after merge: the failed attempt is marked rolled back (`prisma migrate resolve --rolled-back`) so `migrate deploy` re-applies this fixed version.

No ADR change needed: ADR-002 already names expand/backfill/contract as the strategy once real data exists — that condition simply arrived earlier than assumed. No user-visible behavior change (CHANGELOG exempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)