### PR TITLE
test(api): regression test for import route topic ownership (#55)

### DIFF
--- a/src/app/api/v1/lists/import/__tests__/route.test.ts
+++ b/src/app/api/v1/lists/import/__tests__/route.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import { POST } from '../route'
+import { SESSION_COOKIE_NAME } from '@/lib/auth'
+
+const {
+  topicFindFirst,
+  topicCreate,
+  listFindFirst,
+  listFindUnique,
+  prismaTransaction,
+} = vi.hoisted(() => ({
+  topicFindFirst: vi.fn(),
+  topicCreate: vi.fn(),
+  listFindFirst: vi.fn(),
+  listFindUnique: vi.fn(),
+  prismaTransaction: vi.fn(),
+}))
+
+const mockSession = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    topic: {
+      findFirst: topicFindFirst,
+      create: topicCreate,
+    },
+    list: {
+      findFirst: listFindFirst,
+      findUnique: listFindUnique,
+    },
+    $transaction: prismaTransaction,
+  },
+}))
+
+vi.mock('@/lib/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth')>('@/lib/auth')
+  return {
+    ...actual,
+    getSessionForToken: mockSession,
+  }
+})
+
+const importPayload = {
+  topic: 'Animals',
+  name: 'Wildlife',
+  version: 1,
+  items: [
+    { answer: 'cat', clue: 'Feline friend' },
+    { answer: 'dog', clue: 'Man’s best friend' },
+    { answer: 'fox', clue: 'Sly woodland canine' },
+    { answer: 'owl', clue: 'Nocturnal bird' },
+    { answer: 'bear', clue: 'Hibernating giant' },
+  ],
+}
+
+const importRequest = (cookie = `${SESSION_COOKIE_NAME}=token-123`) =>
+  new NextRequest('http://localhost/api/v1/lists/import', {
+    method: 'POST',
+    body: JSON.stringify(importPayload),
+    headers: {
+      'content-type': 'application/json',
+      ...(cookie ? { cookie } : {}),
+    },
+  })
+
+describe('/api/v1/lists/import POST handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSession.mockReset()
+    mockSession.mockResolvedValue({ user: { id: 'user-1' } })
+  })
+
+  // Regression test for #55: the auto-create-Topic path must scope the lookup to the
+  // authenticated user and create the topic owned by them.
+  it('scopes the topic lookup by owner and auto-creates the topic owned by the importer', async () => {
+    const topicId = 'ctopic1234567890123456789'
+    topicFindFirst.mockResolvedValueOnce(null)
+    topicCreate.mockResolvedValueOnce({ id: topicId, name: 'Animals', userId: 'user-1' })
+    listFindFirst.mockResolvedValueOnce(null)
+
+    const createdList = { id: 'clist1234567890123456789', topicId, name: 'Wildlife', source: 'UPLOAD' }
+    prismaTransaction.mockImplementationOnce(async (callback: (tx: unknown) => Promise<unknown>) =>
+      callback({
+        list: { create: vi.fn(async () => createdList) },
+        listItem: { create: vi.fn(async ({ data }: { data: object }) => ({ id: 'item-1', ...data })) },
+      }),
+    )
+    listFindUnique.mockResolvedValueOnce({
+      ...createdList,
+      items: [],
+      topic: { id: topicId, name: 'Animals' },
+      _count: { items: 5, puzzles: 0 },
+    })
+
+    const response = await POST(importRequest())
+    expect(response.status).toBe(201)
+
+    expect(topicFindFirst).toHaveBeenCalledWith({
+      where: { name: 'Animals', userId: 'user-1' },
+    })
+    expect(topicCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({ name: 'Animals', userId: 'user-1' }),
+    })
+  })
+
+  it('reuses an existing topic only when it belongs to the importer', async () => {
+    const topicId = 'ctopic1234567890123456789'
+    topicFindFirst.mockResolvedValueOnce({ id: topicId, name: 'Animals', userId: 'user-1' })
+    listFindFirst.mockResolvedValueOnce(null)
+
+    const createdList = { id: 'clist1234567890123456789', topicId, name: 'Wildlife', source: 'UPLOAD' }
+    prismaTransaction.mockImplementationOnce(async (callback: (tx: unknown) => Promise<unknown>) =>
+      callback({
+        list: { create: vi.fn(async () => createdList) },
+        listItem: { create: vi.fn(async ({ data }: { data: object }) => ({ id: 'item-1', ...data })) },
+      }),
+    )
+    listFindUnique.mockResolvedValueOnce({
+      ...createdList,
+      items: [],
+      topic: { id: topicId, name: 'Animals' },
+      _count: { items: 5, puzzles: 0 },
+    })
+
+    const response = await POST(importRequest())
+    expect(response.status).toBe(201)
+
+    expect(topicFindFirst).toHaveBeenCalledWith({
+      where: { name: 'Animals', userId: 'user-1' },
+    })
+    expect(topicCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    mockSession.mockResolvedValueOnce(null)
+
+    const response = await POST(importRequest(''))
+    expect(response.status).toBe(401)
+    expect(topicFindFirst).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #55.

The build-break half of #55 turned out to be a local false alarm — the type error came from a stale generated Prisma client (`node_modules/.prisma` generated from #48's schema while a pre-ownership branch was checked out); clean main builds fine in CI. The substantive halves are now covered:

- Import route creates Topics scoped to the authenticated user — shipped in #48.
- **Regression test** (this PR): the auto-create-Topic path scopes the lookup by owner, creates the topic owned by the importer, and rejects unauthenticated requests. This was the untested path #41/#55 flagged.

Test-only change: no user-visible behavior, CHANGELOG exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)