### PR TITLE
fix(ci): pass required inputs to Neon create-branch action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,9 @@ jobs:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch_name: ci-pr-${{ github.event.pull_request.number }}
           api_key: ${{ secrets.NEON_API_KEY }}
+          username: neondb_owner
+          database: crosswise
+          prisma: 'true'
 
       - name: Apply + verify migrations on the branch
         if: steps.neon_secrets.outputs.present == 'true'


### PR DESCRIPTION
Fixes #61.

Once the `NEON_API_KEY`/`NEON_PROJECT_ID` repo secrets are set, the ephemeral-branch step would have failed on its first real run:

- `username` is a **required** input of `create-branch-action@v5` — never passed. Now `neondb_owner` (the role from our connection string; role names aren't secrets).
- `database` defaults to `neondb`; ours is `crosswise` — the composed `db_url` would have pointed at a nonexistent database.
- `prisma: 'true'` so the emitted URL is formatted for Prisma, which is what consumes it (`prisma migrate deploy` + `migrate status`).

Secrets scoping (for the record): these are **repo-level** Actions secrets, not environment secrets — `migrations-check` runs on `pull_request` with no `environment:` key, so environment-scoped secrets would never reach it.

Workflow-only change, CHANGELOG exempt. The step still self-skips until the secrets are added; the first PR after they're set exercises it for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)