### PR TITLE
chore: add .env.example for local setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy to .env and fill in. .env is gitignored — never commit real credentials.
+
+# PostgreSQL connection string, consumed by Prisma (prisma/schema.prisma).
+# For local development, point this at a Neon BRANCH of the crosswise project,
+# not the primary branch — the primary holds real user data (see #57).
+# Create one in the Neon console (Branches -> New branch, e.g. "dev") and copy
+# its connection string. Same for a local Postgres if you prefer:
+# postgresql://user:password@localhost:5432/crosswise
+DATABASE_URL=""


### PR DESCRIPTION
Adds the `.env.example` that `ai/agent-setup.md`'s one-time setup already references. `DATABASE_URL` is the only required variable (Prisma reads it from `prisma/schema.prisma`); the comments steer local development toward a **Neon branch** instead of the primary branch, since the primary holds real user data (#57).

This PR is also the first run of `migrations-check` with `NEON_API_KEY`/`NEON_PROJECT_ID` configured — the ephemeral-branch validation (create branch → `prisma migrate deploy` + `migrate status` → delete branch) executes for real instead of self-skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)