### PR TITLE
fix(ci): deploy with current Vercel CLI (v25 pins a rejected version)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Deploy to Vercel (Production)
         uses: amondnet/vercel-action@v25
         with:
+          # v25 pins Vercel CLI 25.1.0, which Vercel's API now rejects
+          # (requires >= 47.2.2) — always deploy with the current CLI.
+          vercel-version: latest
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
Follow-up to #65 / refs #64. The v25 action bump fixed the IDE metadata error but introduced a runtime regression: v25 pins **Vercel CLI 25.1.0**, and Vercel's API now requires **>= 47.2.2**, so the first post-merge deploy on main failed (`Error! Your Vercel CLI version is outdated`). v20 had worked only because it never pinned a CLI version.

`vercel-version: latest` restores unpinned behavior (currently CLI 55.0.0) — resilient to Vercel ratcheting its minimum again.

Deploy verified on the push-to-main run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)