### PR TITLE
fix(api): restore deterministic puzzle generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ and this project adheres to SemVer.
 ### Changed
 - **BREAKING:** Topics are now owned per-user — an owner column is added and topic names are unique per user rather than globally. Requires a database migration plus an ownership backfill for existing data before deploy (#34).
 ### Fixed
+- Puzzle generation is deterministic again: the same list and seed always reproduce the same puzzle, and omitting a seed now uses a stable content-derived default instead of the current time (#35)
 ### Security
 - Enforce per-user data isolation: every topics/lists/puzzles query is scoped to the authenticated user, so a user can only read or modify their own data; non-owned resources return 404 (#34).

--- a/docs/architecture/decisions/ADR-006-puzzle-seed-contract.md
+++ b/docs/architecture/decisions/ADR-006-puzzle-seed-contract.md
@@ -1,0 +1,53 @@
+# ADR-006: Puzzle generation seed contract
+
+**Status:** Proposed
+**Date:** 2026-07-10
+**Deciders:** dragondad22
+**Related ADRs:** ADR-005 (AI list generation stays non-deterministic; puzzle generation from a list stays seeded)
+
+## 1. Context
+
+CLAUDE.md lists deterministic generation as a non-negotiable: "puzzle generation is
+seeded and reproducible for a given list + seed." The implementation violated it (#35):
+the generate route shuffled candidate words with unseeded `Math.random()`, defaulted the
+seed to `Date.now()`-based strings (computed twice, so the stored seed could even differ
+from the one used), and the generator itself fell back to `Math.random()` when no seed
+was given. The same request therefore produced different puzzles on every call, and even
+an explicit seed did not reproduce a puzzle. Determinism is also a prerequisite for
+size/word-count selection (#22) and difficulty-aware generation (#33).
+
+A contract was needed for (a) what a seed guarantees, (b) where the seed comes from when
+the client omits it, and (c) how clients get variety.
+
+## 2. Decision
+
+- **Reproducibility guarantee (server):** the same (list content, seed, grid size)
+  always produces the same grid and numbering. A single seeded PRNG
+  (`seedrandom(seed)`) drives *all* randomness on the generation path — word selection
+  (capping at 150 items) and placement. `Math.random()`/`Date.now()` are banned from
+  the path.
+- **Explicit seed:** used verbatim and persisted on the puzzle, so any puzzle can be
+  regenerated from its stored (list, seed).
+- **Omitted seed:** the API derives a stable default — `deriveListSeed(listId, items)`,
+  an FNV-1a hash of the list id + order-independent item content. Re-requesting without
+  edits reproduces the same puzzle; editing the list changes the default.
+- **Variety is the client's job:** a client wanting a different puzzle for the same
+  list passes a fresh explicit seed (the web UI's generate/regenerate buttons do this).
+  The server never invents randomness.
+
+## 3. Consequences
+
+**Good**
+- The non-negotiable holds and is enforced by unit + API tests (same seed → identical
+  output; omitted seed → stable, content-derived).
+- Stored puzzles are reproducible from their persisted seed — useful for debugging,
+  sharing, and future features (#22, #33) that need stable selection.
+- The stored seed always matches the seed actually used (the double-`Date.now()`
+  mismatch is gone).
+
+**Trade-offs**
+- Generating without a seed no longer yields variety; clients must opt into variety
+  with explicit seeds. The existing web UI already sends explicit seeds, so behavior
+  there is unchanged.
+- The default seed hash (FNV-1a 32-bit) is not cryptographic — acceptable, as it only
+  needs stability, not unpredictability.

--- a/docs/architecture/decisions/ADR_INDEX.md
+++ b/docs/architecture/decisions/ADR_INDEX.md
@@ -2,7 +2,7 @@
 
 CrossWise
 
-**Updated:** 2026-06-24
+**Updated:** 2026-07-10
 
 This index tracks all architectural decisions for CrossWise:
 - Completed ADRs
@@ -20,6 +20,7 @@ Status labels: **Proposed** | **Accepted** | **Rejected** | **Superseded**
 |-------|-------|--------|------|
 | ADR-001 | Per-user ownership of topics, lists, and puzzles | Accepted | `ADR-001-user-data-ownership-model.md` |
 | ADR-002 | Production DB migration & backfill strategy | Accepted | `ADR-002-db-migration-strategy.md` |
+| ADR-006 | Puzzle generation seed contract | Proposed | `ADR-006-puzzle-seed-contract.md` |
 
 ---
 

--- a/docs/puzzle-generation-flow.md
+++ b/docs/puzzle-generation-flow.md
@@ -15,11 +15,23 @@ Describe how the system generates a new crossword from a list.
 ## Step-by-Step
 1. Client posts `{ listId, seed?, gridSize? }` to `/api/v1/puzzles/generate`.
 2. API fetches list + items from Prisma.
-3. API shuffles items and limits to 150 entries.
-4. `CrosswordGenerator` preprocesses answers and searches for a placement.
-5. On success, API stores `grid`, `numbering`, and `settings` JSON blobs.
+3. API resolves the seed (see Seed Contract below).
+4. `CrosswordGenerator` selects up to 150 items via its seeded RNG, preprocesses
+   answers, and searches for a placement — the same RNG drives selection and placement.
+5. On success, API stores `grid`, `numbering`, `settings` JSON blobs and the resolved seed.
 6. API returns `{ puzzleId, seed, metrics }`.
 7. Client navigates to `/solve/:puzzleId`.
+
+## Seed Contract (#35, ADR-006)
+- Generation is fully deterministic: the same `(list content, seed, gridSize)` always
+  produces the same grid and numbering. No `Math.random()` or `Date.now()` on the path.
+- If the client supplies `seed`, it is used verbatim and stored on the puzzle.
+- If the client omits `seed`, the API derives a stable default from the list id +
+  item content (`deriveListSeed` in `src/lib/crossword-generator.ts`) — editing the
+  list changes the default; re-requesting without edits reproduces the same puzzle.
+- Clients that want a *different* puzzle for the same list pass a fresh explicit seed
+  (the web UI does this on generate/regenerate). Variety is the client's choice;
+  reproducibility is the server's guarantee.
 
 ```mermaid
 flowchart TD
@@ -47,4 +59,4 @@ flowchart TD
 
 ## Key Files
 - `src/app/api/v1/puzzles/generate/route.ts`
-- `src/lib/generator/CrosswordGenerator.ts`
+- `src/lib/crossword-generator.ts`

--- a/docs/specs/CROSSWISE_SPEC.md
+++ b/docs/specs/CROSSWISE_SPEC.md
@@ -35,7 +35,7 @@ This document is the authoritative product + engineering specification for the c
    - Export list as JSON per import schema.
 
 3. **Puzzle generation**
-   - Generate from a list using up to 150 items, randomized selection, seeded placement.
+   - Generate from a list using up to 150 items; selection and placement are seeded and reproducible (ADR-006).
    - Grid size defaults to 15x15, with optional 9–19 range per axis.
    - Algorithm prioritizes longest words, requires connected component, avoids adjacent touching except intersections, and targets 90%+ placement.
    - Store puzzle grid, numbering, and settings in database as JSON strings.
@@ -266,6 +266,10 @@ Authentication: cookie `crosswise_session` required for most endpoints.
 
 ## Puzzle Generation Details
 - Uses `CrosswordGenerator` with backtracking + scoring.
+- Fully deterministic (ADR-006): a single seeded RNG drives word selection (up to 150
+  items) and placement, so the same (list content, seed, grid size) always reproduces
+  the same puzzle. An explicit request seed is used verbatim; an omitted seed defaults
+  to a stable hash of list id + item content, never the clock.
 - Places longest words first. First word placed at center, across.
 - Valid placement rules:
   - No out-of-bounds.

--- a/src/app/api/v1/puzzles/generate/__tests__/route.test.ts
+++ b/src/app/api/v1/puzzles/generate/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import { POST } from '../route'
+import { deriveListSeed } from '@/lib/crossword-generator'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    list: { findFirst: vi.fn() },
+    puzzle: { create: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/auth', () => ({
+  SESSION_COOKIE_NAME: 'crosswise_session',
+  getSessionForToken: vi.fn(),
+}))
+
+import { prisma } from '@/lib/db'
+import { getSessionForToken } from '@/lib/auth'
+
+const LIST_ID = 'clist0000000000000000001'
+
+// Two intersecting words place successfully regardless of seed, keeping these
+// tests about the seed contract rather than placement strength.
+const listItems = [
+  { answer: 'Cat', clue: 'Feline friend' },
+  { answer: 'Car', clue: 'Road vehicle' },
+]
+
+function makeRequest(body: Record<string, unknown>, { authenticated = true } = {}) {
+  return new NextRequest('http://localhost/api/v1/puzzles/generate', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: authenticated ? { cookie: 'crosswise_session=test-token' } : {},
+  })
+}
+
+describe('POST /api/v1/puzzles/generate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getSessionForToken).mockResolvedValue({
+      user: { id: 'user1' },
+    } as Awaited<ReturnType<typeof getSessionForToken>>)
+    vi.mocked(prisma.list.findFirst).mockResolvedValue({
+      id: LIST_ID,
+      items: listItems,
+    } as Awaited<ReturnType<typeof prisma.list.findFirst>>)
+    vi.mocked(prisma.puzzle.create).mockImplementation(
+      (async ({ data }: { data: { seed: string } }) => ({ id: 'puzzle1', ...data })) as never,
+    )
+  })
+
+  it('returns identical puzzles for two calls with the same seed', async () => {
+    const body = { listId: LIST_ID, seed: 'fixed-seed' }
+    const first = await (await POST(makeRequest(body))).json()
+    const second = await (await POST(makeRequest(body))).json()
+
+    expect(first.success).toBe(true)
+    expect(second.data.grid).toEqual(first.data.grid)
+    expect(second.data.numbering).toEqual(first.data.numbering)
+    expect(second.data.seed).toBe('fixed-seed')
+  })
+
+  it('uses a stable content-derived seed when the client omits one', async () => {
+    const first = await (await POST(makeRequest({ listId: LIST_ID }))).json()
+    const second = await (await POST(makeRequest({ listId: LIST_ID }))).json()
+
+    expect(first.data.seed).toBe(deriveListSeed(LIST_ID, listItems))
+    expect(second.data.seed).toBe(first.data.seed)
+    expect(second.data.grid).toEqual(first.data.grid)
+  })
+
+  it('persists the same seed it generated with', async () => {
+    await (await POST(makeRequest({ listId: LIST_ID }))).json()
+
+    expect(vi.mocked(prisma.puzzle.create).mock.calls[0][0].data.seed).toBe(
+      deriveListSeed(LIST_ID, listItems),
+    )
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    const response = await POST(makeRequest({ listId: LIST_ID }, { authenticated: false }))
+    expect(response.status).toBe(401)
+  })
+
+  it("returns 404 for a list the user doesn't own", async () => {
+    vi.mocked(prisma.list.findFirst).mockResolvedValue(null)
+    const response = await POST(makeRequest({ listId: LIST_ID }))
+    expect(response.status).toBe(404)
+  })
+})

--- a/src/app/api/v1/puzzles/generate/route.ts
+++ b/src/app/api/v1/puzzles/generate/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 import { GeneratePuzzleSchema } from '@/lib/validation'
-import { CrosswordGenerator } from '@/lib/crossword-generator'
+import { CrosswordGenerator, deriveListSeed } from '@/lib/crossword-generator'
 import { getSessionForToken, SESSION_COOKIE_NAME } from '@/lib/auth'
 
 const unauthorizedResponse = () =>
@@ -49,24 +49,25 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Determine number of items to use (random selection up to 150)
-    const maxItems = Math.min(150, list.items.length)
-    const itemsToUse = list.items
-      .sort(() => Math.random() - 0.5) // Shuffle
-      .slice(0, maxItems)
-      .map((item) => ({
-        answer: item.answer,
-        clue: item.clue,
-      }))
+    const items = list.items.map((item) => ({
+      answer: item.answer,
+      clue: item.clue,
+    }))
 
-    // Generate puzzle
+    // Seed contract (#35, ADR-006): an explicit seed is used verbatim; otherwise the
+    // default is derived from the list id + content, never from the clock. The same
+    // (list, seed) always reproduces the same puzzle — the generator's seeded RNG
+    // drives both word selection (up to 150 items) and placement.
+    const seed = validated.seed || deriveListSeed(list.id, items)
+
     const generator = new CrosswordGenerator({
       gridSize,
-      seed: validated.seed || `${Date.now()}_${list.id}`,
+      seed,
       maxAttempts: 300,
+      maxWords: 150,
     })
 
-    const result = generator.generate(itemsToUse)
+    const result = generator.generate(items)
 
     if (!result.success) {
       return NextResponse.json(
@@ -89,7 +90,7 @@ export async function POST(request: NextRequest) {
     const puzzle = await prisma.puzzle.create({
       data: {
         listId: validated.listId,
-        seed: validated.seed || `${Date.now()}_${list.id}`,
+        seed,
         grid: JSON.stringify(result.grid),
         numbering: JSON.stringify(result.numbering),
         settings: JSON.stringify({

--- a/src/lib/__tests__/crossword-generator.test.ts
+++ b/src/lib/__tests__/crossword-generator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { CrosswordGenerator } from '../crossword-generator'
+import { CrosswordGenerator, deriveListSeed } from '../crossword-generator'
 
 const intersectingWords = [
   { answer: 'Crossword', clue: 'Type of word puzzle' },
@@ -93,5 +93,56 @@ describe('CrosswordGenerator', () => {
     expect(result.success).toBe(false)
     expect(result.placedWords).toBe(0)
     expect(result.totalWords).toBe(0)
+  })
+
+  it('produces identical output for the same words and seed', () => {
+    const options = { gridSize: { rows: 10, cols: 10 }, seed: 'determinism', maxAttempts: 50 }
+    const first = new CrosswordGenerator(options).generate(intersectingWords)
+    const second = new CrosswordGenerator(options).generate(intersectingWords)
+
+    expect(second).toEqual(first)
+  })
+
+  it('selects the same maxWords subset for the same seed', () => {
+    const options = {
+      gridSize: { rows: 10, cols: 10 },
+      seed: 'subset-determinism',
+      maxAttempts: 50,
+      maxWords: 4,
+    }
+    const first = new CrosswordGenerator(options).generate(intersectingWords)
+    const second = new CrosswordGenerator(options).generate(intersectingWords)
+
+    expect(first.totalWords).toBe(4)
+    expect(second).toEqual(first)
+  })
+
+  it('is deterministic when no seed is provided', () => {
+    const options = { gridSize: { rows: 10, cols: 10 }, maxAttempts: 50 }
+    const first = new CrosswordGenerator(options).generate(intersectingWords)
+    const second = new CrosswordGenerator(options).generate(intersectingWords)
+
+    expect(second).toEqual(first)
+  })
+})
+
+describe('deriveListSeed', () => {
+  const items = [
+    { answer: 'Crossword', clue: 'Type of word puzzle' },
+    { answer: 'Words', clue: 'Units of language' },
+  ]
+
+  it('is stable regardless of item order', () => {
+    const reversed = [...items].reverse()
+    expect(deriveListSeed('list1', reversed)).toBe(deriveListSeed('list1', items))
+  })
+
+  it('changes when list content changes', () => {
+    const edited = [items[0], { answer: 'Words', clue: 'A different clue' }]
+    expect(deriveListSeed('list1', edited)).not.toBe(deriveListSeed('list1', items))
+  })
+
+  it('changes when the list id changes', () => {
+    expect(deriveListSeed('list2', items)).not.toBe(deriveListSeed('list1', items))
   })
 })

--- a/src/lib/crossword-generator.ts
+++ b/src/lib/crossword-generator.ts
@@ -27,6 +27,33 @@ export interface GeneratorOptions {
   gridSize?: { rows: number; cols: number }
   maxAttempts?: number
   seed?: string
+  maxWords?: number
+}
+
+// Fallback when a caller constructs a generator without a seed. A constant (not a
+// random value) so generation stays reproducible for a given word set (#35).
+export const DEFAULT_GENERATOR_SEED = 'crosswise'
+
+// FNV-1a 32-bit — cheap, dependency-free, stable across runs. Not cryptographic;
+// only used to derive default seeds.
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash
+}
+
+// Default seed for a puzzle generated without an explicit seed: stable for a given
+// list id + content, independent of item order and of when the request is made.
+// Editing the list's items changes the default seed (and thus the default puzzle).
+export function deriveListSeed(listId: string, items: { answer: string; clue: string }[]): string {
+  const canonical = items
+    .map((item) => `${item.answer}\u0000${item.clue}`)
+    .sort()
+    .join('\u0001')
+  return `list:${listId}:${fnv1a(canonical).toString(36)}`
 }
 
 export class CrosswordGenerator {
@@ -35,12 +62,14 @@ export class CrosswordGenerator {
   private placedWords: WordPlacement[] = []
   private gridSize: { rows: number; cols: number }
   private maxAttempts: number
+  private maxWords?: number
 
   constructor(options: GeneratorOptions = {}) {
-    const seed = options.seed || Math.random().toString()
+    const seed = options.seed || DEFAULT_GENERATOR_SEED
     this.rng = seedrandom(seed)
     this.gridSize = options.gridSize || { rows: 15, cols: 15 }
     this.maxAttempts = options.maxAttempts || 300
+    this.maxWords = options.maxWords
     this.grid = this.createEmptyGrid()
   }
 
@@ -52,10 +81,17 @@ export class CrosswordGenerator {
     totalWords: number
     conflictingWords?: string[]
   } {
+    // Step 0: Select the candidate pool through the seeded RNG so word selection
+    // is as reproducible as placement (#35).
+    const pool =
+      this.maxWords && words.length > this.maxWords
+        ? this.shuffleArray(words).slice(0, this.maxWords)
+        : words
+
     // Step 1: Preprocess words
-    const processedWords = this.preprocessWords(words)
+    const processedWords = this.preprocessWords(pool)
     if (processedWords.length === 0) {
-      return { success: false, placedWords: 0, totalWords: words.length }
+      return { success: false, placedWords: 0, totalWords: pool.length }
     }
 
     // Step 2: Try generation with multiple attempts
@@ -74,7 +110,7 @@ export class CrosswordGenerator {
       }
 
       // Success criteria: placed at least 90% of words
-      if (result.length >= Math.floor(words.length * 0.9)) {
+      if (result.length >= Math.floor(pool.length * 0.9)) {
         break
       }
 
@@ -82,14 +118,14 @@ export class CrosswordGenerator {
     }
 
     this.placedWords = bestResult
-    const successRate = bestResult.length / words.length
+    const successRate = bestResult.length / pool.length
 
     if (successRate < 0.9) {
       const conflictingWords = this.findConflictingWords(processedWords, bestResult)
       return {
         success: false,
         placedWords: bestResult.length,
-        totalWords: words.length,
+        totalWords: pool.length,
         conflictingWords,
       }
     }
@@ -104,7 +140,7 @@ export class CrosswordGenerator {
       grid: finalGrid,
       numbering,
       placedWords: bestResult.length,
-      totalWords: words.length,
+      totalWords: pool.length,
     }
   }
 


### PR DESCRIPTION
Closes #35

## What

Restores the CLAUDE.md non-negotiable "puzzle generation is seeded and reproducible for a given list + seed":

- **Route** (`src/app/api/v1/puzzles/generate/route.ts`): removed the unseeded `.sort(() => Math.random() - 0.5)` shuffle and the `Date.now()` default seed (which was computed twice — the stored seed could differ from the one actually used). The seed is now resolved once and persisted verbatim.
- **Generator** (`src/lib/crossword-generator.ts`): word selection (150-item cap) moved into the generator behind a `maxWords` option so a single seeded RNG drives both selection and placement; the unseeded `Math.random()` constructor fallback replaced with a constant.
- **Default seed contract** (ADR-006, **Proposed — needs review approval**): explicit seed → used verbatim; omitted seed → `deriveListSeed(listId, items)`, a stable FNV-1a hash of list id + order-independent item content. Variety is the client's choice via explicit seeds — the web UI already sends them, so its generate/regenerate behavior is unchanged.

## Consumer sweep

- Web UI callers (`topics/[id]/lists/page.tsx`, `solve/[id]/page.tsx`) pass explicit time-based seeds intentionally (fresh puzzle per click) — legitimate under the contract, untouched.
- `CrosswordGenerator` consumers: only the generate route and its tests.

## Tests

- Generator: same (words, seed) → identical output; same seed → same `maxWords` subset; seedless construction deterministic; `deriveListSeed` order-insensitive / content- and id-sensitive.
- API: two same-seed calls return identical grid+numbering; omitted seed is stable and content-derived; persisted seed matches the seed used; 401 unauthenticated; 404 non-owned list.
- Full suite 131/131, lint clean, build passes.

## Docs

- `docs/puzzle-generation-flow.md` — seed contract section + fixed stale key-file path
- `docs/specs/CROSSWISE_SPEC.md` — generation details + functional requirement
- `docs/architecture/decisions/ADR-006-puzzle-seed-contract.md` (+ index)
- `CHANGELOG.md` — Fixed entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)