### PR TITLE
chore(infra): commit kit 0.8.0 additive scaffold + strip adapted-standard banners

### DIFF
--- a/.github/workflows/pr-validation.yml.example
+++ b/.github/workflows/pr-validation.yml.example
@@ -1,0 +1,84 @@
+# pr-validation.yml.example — PR-validation CI seed (kit decision T10.1).
+#
+# ACTIVATION: fill the {{TOKENS}} (the /bootstrap interview does this), uncomment
+# the blocks the project actually has, and rename to pr-validation.yml. It ships
+# as .example so a fresh project doesn't run a red workflow before it's configured.
+#
+# SCOPE: environment-independent PR validation only — these gates run on every PR
+# regardless of where the project deploys. Deploy/CD is deliberately NOT here: it
+# arrives as the deploy-ci module when environments/deploy targets are decided.
+#
+# FORGE-AGNOSTIC NOTE: GitHub Actions is the paved-road default
+# (bootstrap/PAVED_ROAD.md). On another CI system, the durable content of this
+# file is the GATE LIST — what runs on PR (below) vs on merge vs on a schedule.
+# Keep the gates, translate the syntax.
+#
+# Once live, document the actual gates in ai/agent-setup.md -> CI Quality Gates.
+
+name: PR validation
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    # --- Service containers -------------------------------------------------
+    # Uncomment when tests need a real backing service (paved road: PostgreSQL).
+    # services:
+    #   postgres:
+    #     image: postgres:16
+    #     env:
+    #       POSTGRES_PASSWORD: postgres
+    #     ports: ['5432:5432']
+    #     options: >-
+    #       --health-cmd "pg_isready -U postgres"
+    #       --health-interval 5s --health-timeout 5s --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # TODO: set up the project's runtime + dependency cache, e.g.:
+      # - uses: actions/setup-node@v4
+      #   with: { node-version: 22, cache: npm }
+      # - run: npm ci
+
+      - name: Build / typecheck
+        run: "{{BUILD_COMMAND}}"
+
+      - name: Lint
+        run: "{{LINT_COMMAND}}"
+
+      - name: Tests
+        run: "{{TEST_COMMAND}}"
+
+      - name: Version sync
+        run: bash ai/scripts/check-version-sync.sh
+
+      - name: Dependency scan (SCA)
+        # Fail on high/critical runtime vulnerabilities — gate definition in
+        # ai/STANDARDS/SECURITY_REVIEW_STANDARD.md (CI Security Gates).
+        run: "{{SECURITY_SCAN_COMMAND}}"
+
+      # --- E2E ----------------------------------------------------------------
+      # Uncomment when the project has UI flows. Paved road: Playwright — its
+      # on-failure screenshot/trace/video defaults produce the failure evidence
+      # the kit's diagnostics rules expect.
+      # - name: E2E tests
+      #   run: "{{E2E_COMMAND}}"
+
+      # --- Failure diagnostics -------------------------------------------------
+      # Success is silent. On failure, upload whatever diagnostics the gates
+      # wrote so the failure can be fixed without re-running it. Diagnostic
+      # bundles live in CI artifacts (or gitignored locally) — never committed.
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure-diagnostics
+          path: |
+            testing-reports/
+            test-results/
+          if-no-files-found: ignore

--- a/ai/STANDARDS/GIT_WORKFLOW_STANDARD.md
+++ b/ai/STANDARDS/GIT_WORKFLOW_STANDARD.md
@@ -1,5 +1,3 @@
-*Generic standard from the Claude starter kit — adapt to this project. Replace `{{TOKENS}}`; see `bootstrap/PLACEHOLDERS.md`.*
-
 # Git Workflow Standard
 
 Owner: dragondad22

--- a/ai/STANDARDS/INTERVIEW_STANDARD.md
+++ b/ai/STANDARDS/INTERVIEW_STANDARD.md
@@ -1,5 +1,3 @@
-*Generic standard from the Claude starter kit — adapt to this project. Replace `{{TOKENS}}`; see `bootstrap/PLACEHOLDERS.md`.*
-
 # Interview Standard
 
 ## Purpose

--- a/ai/STANDARDS/ROADMAP_STANDARD.md
+++ b/ai/STANDARDS/ROADMAP_STANDARD.md
@@ -1,5 +1,3 @@
-*Generic standard from the Claude starter kit — adapt to this project. Replace `{{TOKENS}}`; see `bootstrap/PLACEHOLDERS.md`.*
-
 # Roadmap Standard
 
 > Written assuming GitHub Issues + Projects, but the model — intake as typed

--- a/bootstrap/modules/reports/ai/TEMPLATES/ACCEPTANCE_DOC_TEMPLATE.md
+++ b/bootstrap/modules/reports/ai/TEMPLATES/ACCEPTANCE_DOC_TEMPLATE.md
@@ -1,0 +1,87 @@
+*Generic template from the Claude starter kit — adapt to this project. Replace `{{TOKENS}}`; see `bootstrap/PLACEHOLDERS.md`.*
+
+# Acceptance Doc: <{{WORK_ITEM_PREFIX}}-NNN> — <feature / change title>
+
+<!--
+WHAT: the agent-facing acceptance spec for one work item — the criteria the
+change must meet, and their recorded outcomes. Required by the task-issue
+completion gate ("Docs to Update"); consumed by /qa; governed by
+ai/STANDARDS/UAT_SOURCE_OF_TRUTH.md (source precedence, scenario minimums,
+evidence rules).
+
+WHERE: docs/uat/UAT_{{WORK_ITEM_PREFIX}}-NNN.md — this file IS the UAT spec at
+the top of the document-precedence order for its work item.
+
+NOT THIS FILE: the human-facing beta guide (goals-not-steps hand-off for beta
+testers) is a separate artifact — ai/TEMPLATES/BETA_GUIDE_TEMPLATE.md, in
+docs/uat/beta/. Never blend the two audiences in one document.
+
+RESULTS: success is silent (exit code + one summary line). A failed gate
+produces a diagnostic bundle (ai/TEMPLATES/DIAGNOSTIC_BUNDLE_TEMPLATE.md) —
+link it from the outcome column; do not paste failure detail here.
+-->
+
+## Sources
+
+Precedence per `ai/STANDARDS/UAT_SOURCE_OF_TRUTH.md` — cite what governs this run:
+
+| Source | Ref |
+|---|---|
+| Feature spec | <SPEC-DOMAIN-NNN, `docs/specs/`> |
+| Implementation plan / work item | <{{WORK_ITEM_PREFIX}}-NNN link> |
+| ADRs / decision log | <ADR-NNN, decision entry — or "none"> |
+
+## Acceptance criteria
+
+Criteria are explicit, written, and traceable — each cites a journey step
+number or edge-case ID (EC-n) from the spec. Never invent criteria mid-run;
+a spec that misses reality must fail visibly here.
+
+| # | Criterion (observable behavior) | Source | Outcome (pass / fail / blocked) | Evidence |
+|---|---|---|---|---|
+| AC-1 | <what must observably happen> | <SPEC-… step 3> | <pass> | <artifact path / API snippet ref> |
+| AC-2 | <…> | <EC-2> | <…> | <…> |
+
+## Edge-case matrix
+
+Minimum set per the standard: 3+ edge cases (invalid input, empty state,
+boundary value), role/permission boundary (if applicable), navigation
+resilience (refresh / back), tenant isolation (if applicable), responsive
+viewports for web (375x812 / 768x1024 / 1280x800).
+
+| # | Case | Input / precondition | Expected | Outcome | Evidence |
+|---|---|---|---|---|---|
+| EC-1 | <invalid input> | <…> | <…> | <…> | <…> |
+
+## UX and accessibility critique
+
+- Clarity: <labels, helper text, error messages actionable?>
+- Friction: <unnecessary steps, ambiguous controls, confusing defaults?>
+- Visual integrity: <spacing/alignment/overflow at the required viewports?>
+- Accessibility basics: <keyboard navigation, visible focus, control labels, contrast check?>
+
+## Automation
+
+- E2E smoke: <`{{E2E_COMMAND}}` — exit code / run link>; failure artifacts
+  (screenshot / trace / video) retained and linked above.
+
+## Blockers, risks, issues
+
+- <filed issues with links; risks accepted and by whom; BLOCKED items with the
+  exact human action required — or "none">
+
+## Self-correction log
+
+| When | Planned path blocked | Adaptation taken |
+|---|---|---|
+| <…> | <…> | <alternate path / role / source reconciliation> |
+
+## Completion gate
+
+Per the standard — this doc is complete only when:
+
+- [ ] Every acceptance criterion has a recorded outcome
+- [ ] The edge-case matrix is fully populated
+- [ ] The UX/accessibility critique is complete
+- [ ] Blockers, risks, and issues are explicitly documented
+- [ ] The E2E smoke ran with failure artifacts retained (or the non-web equivalent)

--- a/bootstrap/modules/reports/ai/TEMPLATES/BETA_GUIDE_TEMPLATE.md
+++ b/bootstrap/modules/reports/ai/TEMPLATES/BETA_GUIDE_TEMPLATE.md
@@ -1,0 +1,89 @@
+*Generic template from the Claude starter kit — adapt to this project. Replace `{{TOKENS}}`; see `bootstrap/PLACEHOLDERS.md`.*
+
+# <Feature name, in the tester's words> — beta test guide
+
+<!--
+WHAT: the human-facing UAT artifact — a hand-off for beta testers, who may be
+non-technical and may never have tested software before. Everything below this
+comment is user-facing text: the audience-first rules apply in full
+(ai/STANDARDS/DOCUMENTATION_STANDARD.md — persona voice, no internal leakage,
+no jargon, no AI-tell prose). The tester never sees this comment block.
+
+GOALS, NOT STEPS — the rule that makes this artifact work. Each task gives a
+scenario, a starting point, and what "done" looks like; NEVER a click-path.
+A step-by-step script explains the joke: the tester succeeds at your steps and
+you learn nothing about whether the UI is discoverable. What a human tester
+uniquely offers is their naïve first pass — it is nonrenewable, and steps
+destroy it. Everything scripted belongs in the acceptance doc
+(ai/TEMPLATES/ACCEPTANCE_DOC_TEMPLATE.md) and the E2E suite instead.
+
+DERIVED, NOT INVENTED: tasks come from the feature spec's journey layer
+(docs/specs/) — the journey with the steps deleted. If a task cannot be stated
+without explaining how to do it, that is a design finding before any tester
+sees it — route it per the "how do I…?" rule in ai/STANDARDS/UI_STANDARD.md
+(ui module) rather than shipping the explanation.
+
+WHEN: drafted at feature-complete; reviewed by a human before testers get it;
+refreshed at release time (the CHANGELOG's Unreleased section is the delta of
+guides to create or update). Testers receive guides only after acceptance
+verification and the E2E smoke are green on a build they can reach.
+
+FEEDBACK ROUTING: a tester asking how to do something → UX/design issue against
+the flow, not help text (ai/STANDARDS/UI_STANDARD.md). Bugs → normal intake
+(ai/STANDARDS/GITHUB_ISSUES.md), with the tester's words quoted as evidence.
+
+NAME + HOME: docs/uat/beta/BETA-<DOMAIN>-NNN-<slug>.md, mirroring the feature
+spec ID. One guide per feature; 3–6 tasks is plenty.
+-->
+
+**For:** <persona name — pick from `docs/PERSONAS.md` and write for them> ·
+**Takes about:** <15> minutes
+
+## Before you start
+
+- You'll need: <plain-language prerequisites — an account, a phone or computer,
+  sample data already set up for you>
+- If you can't even get started, that's a result too — tell us where it stopped.
+
+## What we're asking
+
+Use {{PROJECT_NAME}} the way you naturally would. There are no wrong moves, and
+you can't break anything — <confirm or adjust>. We're testing the product, not
+you: anything confusing is a problem with the product, and it's exactly what we
+want to hear about.
+
+One favor: **please don't ask anyone how to do these tasks.** Working that out
+on your own — or not managing to — is the most useful thing you can show us.
+
+## Task 1 — <plain-language name>
+
+- **The situation:** <a scenario from the persona's world — "You just got back
+  from a home visit and need to record what happened.">
+- **Start from:** <"the main screen — then go wherever feels natural">
+- **You're done when:** <the outcome, from the tester's point of view — "you
+  can find that visit again later">
+
+Afterwards, jot down:
+
+- Did you finish? If you gave up, where?
+- Where did you pause, guess, or feel unsure?
+- Did anything happen that you didn't expect — or not happen that you expected?
+
+## Task 2 — <…>
+
+<Repeat the shape: situation / start from / done when, then the same three
+questions. Cover the sad path as a scenario too — "you typed the wrong thing /
+changed your mind halfway" — without saying what will happen.>
+
+## Wander off the path
+
+When the tasks are done (or you're fed up — also useful to know), spend a few
+minutes exploring anywhere you like. Try whatever you're curious about. If
+something looks odd, slow, or confusing, write it down — unplanned finds are
+often the best ones.
+
+## Sending us your notes
+
+<One obvious channel: a form link, an email address, or a chat — with any
+screenshots you took.> Rough notes are perfect. Thank you — what you send
+genuinely shapes what we build next.

--- a/bootstrap/modules/reports/docs/uat/beta/README.md
+++ b/bootstrap/modules/reports/docs/uat/beta/README.md
@@ -1,0 +1,9 @@
+# uat/beta — beta test guides
+
+Human-facing beta guides live here: task-based hand-offs for beta testers —
+**goals, not steps** (template: `ai/TEMPLATES/BETA_GUIDE_TEMPLATE.md`).
+
+One guide per feature, ID-anchored to its spec: `BETA-<DOMAIN>-NNN-<slug>.md`
+mirrors the `SPEC-<DOMAIN>-NNN` it derives from (`docs/specs/`). Agent-facing
+acceptance docs stay in `docs/uat/` (the parent directory). Lifecycle,
+sequencing, and feedback routing: `ai/STANDARDS/UAT_SOURCE_OF_TRUTH.md`.

--- a/docs/kit/README.md
+++ b/docs/kit/README.md
@@ -1,0 +1,63 @@
+# The Kit — reference
+
+This project was scaffolded from the **Claude starter kit**: a stack-agnostic
+process layer — standards, checklists, commands, and automation — for building
+software with Claude Code. The journey through it (stages, flowchart, "where
+am I?"): `docs/kit/WORKFLOW.md`. The kit version this project was scaffolded
+from is recorded in `bootstrap/KIT_VERSION`.
+
+## Commands
+
+| Command | What it does | Reach for it when |
+|---|---|---|
+| `/bootstrap` | Runs inception: brief → interview → fill placeholders, founding docs, modules, tracker | Starting out; retrofitting kit pieces later |
+| `/preflight` | Build + test + security + changelog check | Before every PR |
+| `/qa` | QA validation against recent changes | Feature-complete work |
+| `/security` | Security validation | Auth/authz/input-handling changes |
+| `/compliance` | External-standards + obligation check | A change touches APIs, UI, mobile, messaging/UGC, payments, personal data, minors |
+| `/perf` | Performance smoke | The perf signal that matters might have moved |
+| `/release` | Version bump + CHANGELOG roll, in lockstep | `## [Unreleased]` has shipped enough |
+| `/evergreen` | Six-lens standards & process review | ~30-day cadence, non-interruptive |
+| `/conform` | Tidy to current kit standards, no behavior change (`github` = tracker only) | Adopting the kit into an untidy repo |
+| `/rebaseline` | Harvest → pre-answered interview → critique → agreed rebuild plan | Sound concept, wrong implementation |
+
+## Directory map
+
+| Path | What lives there |
+|---|---|
+| `CLAUDE.md` | Root context, loaded every session: non-negotiables, commands, standards index |
+| `ai/agent-setup.md` | Living orientation doc + session-start protocol |
+| `ai/STANDARDS/` | How work is done per area — read the relevant one before working there |
+| `ai/CHECKLISTS/` | Completion gates: coding, QA, validation |
+| `ai/TEMPLATES/` | Issue bodies, feature specs, diagnostic bundles |
+| `ai/scripts/` | Shipped automation: release, version sync, labels, review stubs |
+| `bootstrap/` | The kit's own machinery: question bank, token map, paved-road registry, staged modules, `KIT_VERSION` |
+| `docs/plans/` | Interviews + decision working docs (structured discovery only) |
+| `docs/specs/` | Journey-first feature specs (created at promotion) |
+| `docs/architecture/decisions/` | ADRs |
+| `docs/decision-log.md` | Product/scope decisions |
+| `docs/GLOSSARY.md` · `docs/PERSONAS.md` | Naming authority · persona registry |
+| `docs/compliance/` | What externally binds this project |
+| `docs/runbooks/` | Anything operational done twice |
+| `.claude/commands/` | The slash commands above |
+| `.github/workflows/` | PR-validation CI (from the shipped example) |
+
+Modules installed later add their own pieces (e.g. the reports module ships
+`docs/uat/` + acceptance/beta-guide templates).
+
+## Where does X go?
+
+| X | Home |
+|---|---|
+| An architectural decision | ADR (`docs/architecture/decisions/`) |
+| A product/scope call | `docs/decision-log.md` |
+| A feature idea | `type:feature` issue, Horizon on the board — never a document |
+| Work to do | A tracked issue; branch `<type>/<issue#>-<slug>` |
+| A term someone had to explain | `docs/GLOSSARY.md`, at coin time |
+| A how-to you'll need twice | `docs/runbooks/` |
+| What a feature does | Its spec in `docs/specs/` |
+| Why the interview asked that | `docs/plans/<NNN>-*/` — history, never the spec |
+
+**Keep this folder current:** these two files ride the same-PR rule — a change
+to commands, flow, or structure updates them in the PR that makes it
+(`ai/STANDARDS/DOCUMENTATION_STANDARD.md` keep-current rule).

--- a/docs/kit/WORKFLOW.md
+++ b/docs/kit/WORKFLOW.md
@@ -1,0 +1,119 @@
+# The Kit Workflow — where you are and what's next
+
+The end-to-end journey of a project built with the starter kit, written for
+someone using it for the first time. The companion reference — what the kit
+*is*, every command, the directory map — is `docs/kit/README.md`.
+
+## The flow
+
+```mermaid
+flowchart TD
+    A{New or existing repo?} -->|new| B[Scaffold the kit]
+    A -->|existing| B2[Adoption tier:\n/bootstrap retrofit · /conform · /rebaseline]
+    B2 --> C
+    B --> C[Inception: approve the brief\n000-inception/00-BRIEF.md]
+    C --> D[Answer the interview\nasync, at your pace]
+    D --> E["/bootstrap closes inception:\nplaceholders, founding docs,\nmodules, tracker + board"]
+    E --> F[Human-only setup\nSETUP_CHECKLIST.md → confirm → delete]
+    F --> G[Plan: ideas → type:feature issues\n→ Horizon on the Roadmap view]
+    G --> H[Promote: spec + epic/sub-issues]
+    H --> I[Build loop\nissue → branch → gates → PR → merge]
+    I --> J{Feature complete?}
+    J -->|more work| I
+    J -->|yes| K[Accept: /qa · acceptance doc\n· beta guides if human-tested]
+    K --> L["/release — version + CHANGELOG roll\n(first release → interview retrospective)"]
+    L --> G
+    L -.-> M[Steady state: /evergreen cadence,\nmodule triggers as the project grows]
+```
+
+## The stages
+
+1. **Scaffold.** A new project gets the kit's core at inception; optional
+   modules (db, ui, reports, deploy-ci, sla) arrive staged, installed later
+   when their trigger fires. An existing repo instead picks an adoption tier:
+   `/bootstrap` retrofit (just missing kit pieces), `/conform` (untidy naming/
+   layout/tracker), `/rebaseline` (sound concept, rebuild the implementation).
+
+2. **Inception — brief first.** Before any questions, the AI drafts (or you
+   write) the project brief — `00-BRIEF.md` in the `000-inception/` interview
+   directory under `docs/plans/`: what this project is, for
+   whom, goals, out-of-scope, known constraints. You edit until it says what
+   you mean, then approve it. Only then is the interview generated, seeded by
+   the brief. Answer it async in the files — sessions resume; defaults cover
+   what you defer.
+
+3. **Close inception with `/bootstrap`.** Fills every `{{PLACEHOLDER}}`,
+   generates the founding docs (README, LICENSE, ADRs, decision log,
+   compliance register, glossary, personas), offers the modules that apply
+   now, and sets up labels + the project board (Status lifecycle, Horizon
+   field, saved views).
+
+4. **Human-only setup.** `/bootstrap` writes `SETUP_CHECKLIST.md` at the repo
+   root: tokens, API keys, `gh` scopes, CI secrets, board UI-only steps — with
+   instructions and alternatives. Work through it; when everything's
+   confirmed, the AI offers to delete it. **This is the point where "what do I
+   do now?" flips from setup to building.**
+
+5. **Plan the work.** Ideas land as `type:feature` issues (lightweight — what,
+   who asked, why) and get ordered by **Horizon** (Now / Next / Later) on the
+   board's Roadmap view. Nothing is a document; the roadmap is a view over
+   live issues (`ai/STANDARDS/ROADMAP_STANDARD.md`).
+
+6. **Promote and spec.** When a feature's turn comes it grows its full
+   two-layer body or becomes an epic with sub-issues
+   (`ai/STANDARDS/TASK_ISSUE_STANDARD.md`), and a journey-first spec in
+   `docs/specs/` — **specs are per-feature, created at promotion, not at
+   bootstrap**. Epic-sized work can run its own interview
+   (`001-<slug>/`, same machinery as inception).
+
+7. **The build loop** — the kit deliberately does not prescribe your inner
+   development style (TDD, spike-and-stabilize, whatever fits); it prescribes
+   the *rails around it*:
+   pick an issue from the board (Next) → set it In progress → branch
+   `<type>/<issue#>-<slug>` → build, reading the relevant
+   `ai/STANDARDS/` file for the area → gate completion with
+   `ai/CHECKLISTS/` → `/preflight` → PR (`Closes #N`, CHANGELOG line) →
+   squash-merge → board Done.
+
+8. **Accept.** `/qa`, `/security`, `/compliance`, `/perf` as the change
+   warrants; feature-complete work gets its acceptance doc, and human beta
+   testing (reports module) gets goals-not-steps beta guides.
+
+9. **Release.** `/release` bumps versions in lockstep and rolls the
+   CHANGELOG. The **first release triggers the interview retrospective**:
+   "what did the interview fail to ask?" — gaps become port-back issues
+   against the kit.
+
+10. **Steady state.** The session-start protocol (`ai/agent-setup.md`) keeps
+    the board honest; `/evergreen` runs its six lenses on a ~30-day cadence;
+    module triggers fire as the project grows (first schema → db, first UI
+    code → ui, first deploy target → deploy-ci).
+
+## Where am I?
+
+| You see… | You're at | Do |
+|---|---|---|
+| `{{TOKENS}}` everywhere, no `000-inception/` | Stage 2 | `/bootstrap` (starts the brief) |
+| A brief marked `draft` | Stage 2 | Edit it, approve it |
+| Interview files with `open` questions | Stage 2 | Answer them, then `/bootstrap` |
+| Interview done, tokens still unfilled | Stage 3 | `/bootstrap` |
+| `SETUP_CHECKLIST.md` at the root | Stage 4 | Work through it, confirm, delete |
+| Empty board, no feature issues | Stage 5 | File ideas as `type:feature`, set Horizon |
+| A promoted feature with no spec | Stage 6 | Write the spec, break down the work |
+| An issue assigned to you / In progress | Stage 7 | Build inside the rails |
+| `## [Unreleased]` full of entries | Stage 9 | `/release` |
+| Nothing urgent | Stage 10 | Session-start checks; `/evergreen` if due |
+
+## Right-sizing — the same flow at three scales
+
+The stages never change; their weight does (recommendations in the interview
+are right-sized the same way — smallest thing that works).
+
+- **Weekend tool / personal project:** brief = a paragraph; accept interview
+  defaults liberally (`deferred` is a legitimate end state); no epics — plain
+  task issues; releases whenever it's useful; modules likely never trigger.
+- **Small real product:** the full flow as written; epics for multi-issue
+  features; release cadence tied to beta rounds.
+- **Team / multi-audience product:** add epic interviews per major feature,
+  persona-addressed beta guides, compliance register worked actively, and
+  the roadmap view shared with stakeholders.


### PR DESCRIPTION
Refs #70 (first two checklist items; the /evergreen kit-delta reconcile remains open, so this does not close the issue)

- Commits the six net-new files from the kit 0.8.0 additive scaffold: `.github/workflows/pr-validation.yml.example` (template only — our active `pr-validation.yml` is untouched), the reports-module beta-guide templates, and the `docs/kit/` guide (README + WORKFLOW).
- Strips the line-1 "adapt to this project" banner from `GIT_WORKFLOW_STANDARD.md`, `INTERVIEW_STANDARD.md`, and `ROADMAP_STANDARD.md` — upstream confirmed (kit #112) the banner is an adaptation-pending marker to be removed once a standard is adapted; all three have token-free bodies.
- `bootstrap/KIT_VERSION` intentionally stays 0.6.0 until the kit-delta reconcile bumps it.

Purely internal/process — no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)