### PR TITLE
fix(generation): unwind backtracking symmetrically so words never place twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to SemVer.
 
 ## [Unreleased]
 
+### Fixed
+- Puzzle generation no longer places the same word twice or reports success for puzzles that silently dropped most of the list; placement counts and the success threshold now reflect the real grid (#76)
+
 ## [0.1.0] - 2026-07-10
 
 First tracked release. Covers all functionality shipped to date — topics, word

--- a/src/lib/__tests__/crossword-generator.test.ts
+++ b/src/lib/__tests__/crossword-generator.test.ts
@@ -126,6 +126,91 @@ describe('CrosswordGenerator', () => {
   })
 })
 
+// Realistic vocab list large enough to force backtracking (#76 repro class).
+const biologyWords = [
+  'GLUCOSE',
+  'MITOCHONDRIA',
+  'RIBOSOME',
+  'NUCLEUS',
+  'CYTOPLASM',
+  'MEMBRANE',
+  'ENZYME',
+  'PROTEIN',
+  'CHLOROPLAST',
+  'OSMOSIS',
+  'DIFFUSION',
+  'PHOTOSYNTHESIS',
+  'RESPIRATION',
+  'BACTERIA',
+  'VIRUS',
+  'GENOME',
+  'CHROMOSOME',
+  'MEIOSIS',
+  'MITOSIS',
+  'ORGANELLE',
+  'VACUOLE',
+  'LYSOSOME',
+  'PEPTIDE',
+  'HORMONE',
+].map((answer, i) => ({ answer, clue: `Biology term ${i + 1}` }))
+
+describe('CrosswordGenerator placement invariants (#76)', () => {
+  const generate = (seed: string) =>
+    new CrosswordGenerator({ seed, maxAttempts: 300 }).generate(biologyWords)
+
+  const allClues = (result: ReturnType<CrosswordGenerator['generate']>) => [
+    ...(result.numbering?.across ?? []),
+    ...(result.numbering?.down ?? []),
+  ]
+
+  for (const seed of ['dup-check', 'invariant-a', 'invariant-b']) {
+    it(`never places a word twice (seed ${seed})`, () => {
+      const result = generate(seed)
+      const answers = allClues(result).map((clue) => clue.answer)
+      expect(new Set(answers).size).toBe(answers.length)
+    })
+
+    it(`reports placedWords equal to the clue count and within the input size (seed ${seed})`, () => {
+      const result = generate(seed)
+      if (result.success) {
+        expect(result.placedWords).toBe(allClues(result).length)
+      }
+      expect(result.placedWords).toBeLessThanOrEqual(biologyWords.length)
+      expect(result.totalWords).toBe(biologyWords.length)
+    })
+
+    it(`keeps crossing letters consistent in the final grid (seed ${seed})`, () => {
+      const result = generate(seed)
+      if (!result.success) return
+      for (const clue of allClues(result)) {
+        for (let i = 0; i < clue.answer.length; i++) {
+          const row = clue.direction === 'down' ? clue.row + i : clue.row
+          const col = clue.direction === 'across' ? clue.col + i : clue.col
+          const cell = result.grid!.cells[row][col]
+          expect(cell.type).toBe('cell')
+          expect(cell.letter).toBe(clue.answer[i])
+        }
+      }
+    })
+  }
+
+  it('only reports success when the placement threshold is genuinely met', () => {
+    const result = generate('dup-check')
+    const distinctPlaced = new Set(allClues(result).map((clue) => clue.answer)).size
+    if (result.success) {
+      expect(distinctPlaced).toBeGreaterThanOrEqual(Math.floor(biologyWords.length * 0.9))
+    } else {
+      expect(result.conflictingWords).toBeDefined()
+    }
+  })
+
+  it('stays within the generation time budget', () => {
+    const start = performance.now()
+    generate('perf-budget')
+    expect(performance.now() - start).toBeLessThan(2000)
+  })
+})
+
 describe('deriveListSeed', () => {
   const items = [
     { answer: 'Crossword', clue: 'Type of word puzzle' },

--- a/src/lib/crossword-generator.ts
+++ b/src/lib/crossword-generator.ts
@@ -56,6 +56,11 @@ export function deriveListSeed(listId: string, items: { answer: string; clue: st
   return `list:${listId}:${fnv1a(canonical).toString(36)}`
 }
 
+// Total backtracking expansions allowed per generate() call. A counter (not a time
+// budget) so the cutoff is deterministic for a given seed regardless of machine speed.
+// When exhausted, the search degrades to greedy placement (no unwinding).
+const DEFAULT_SEARCH_BUDGET = 4000
+
 export class CrosswordGenerator {
   private rng: () => number
   private grid: (string | null)[][]
@@ -63,6 +68,7 @@ export class CrosswordGenerator {
   private gridSize: { rows: number; cols: number }
   private maxAttempts: number
   private maxWords?: number
+  private searchBudget = DEFAULT_SEARCH_BUDGET
 
   constructor(options: GeneratorOptions = {}) {
     const seed = options.seed || DEFAULT_GENERATOR_SEED
@@ -97,6 +103,7 @@ export class CrosswordGenerator {
     // Step 2: Try generation with multiple attempts
     let bestResult: WordPlacement[] = []
     let attempts = 0
+    this.searchBudget = DEFAULT_SEARCH_BUDGET
 
     while (attempts < this.maxAttempts) {
       this.grid = this.createEmptyGrid()
@@ -111,6 +118,12 @@ export class CrosswordGenerator {
 
       // Success criteria: placed at least 90% of words
       if (result.length >= Math.floor(pool.length * 0.9)) {
+        break
+      }
+
+      // Budget exhausted: further attempts would run greedy-only and rarely beat
+      // what we already have — stop instead of burning CPU.
+      if (this.searchBudget <= 0) {
         break
       }
 
@@ -168,8 +181,12 @@ export class CrosswordGenerator {
     return freq
   }
 
+  // Depth-first placement with symmetric backtracking. Every branch that is not
+  // accepted unwinds exactly the placements it added (checkpoint-based), so a word
+  // can never remain on the grid twice (#76). Returns a snapshot of the best
+  // placement set found in this subtree; the caller rebuilds the grid from it.
   private generateWithBacktracking(words: WordEntry[]): WordPlacement[] {
-    if (words.length === 0) return this.placedWords
+    if (words.length === 0) return [...this.placedWords]
 
     const word = words[0]
     const remainingWords = words.slice(1)
@@ -180,14 +197,11 @@ export class CrosswordGenerator {
       const centerCol = Math.floor((this.gridSize.cols - word.length) / 2)
 
       if (this.tryPlaceWord(word, centerRow, centerCol, 'across')) {
-        const result = this.generateWithBacktracking(remainingWords)
-        if (result.length > 0) return result
-
-        // Backtrack
-        this.removeWord(this.placedWords[this.placedWords.length - 1])
+        return this.generateWithBacktracking(remainingWords)
       }
 
-      return []
+      // Word doesn't fit (e.g. longer than the grid) — continue without it.
+      return this.generateWithBacktracking(remainingWords)
     }
 
     // Find all possible placements for this word
@@ -196,21 +210,51 @@ export class CrosswordGenerator {
     // Sort by score (best first)
     candidates.sort((a, b) => b.score - a.score)
 
+    // A subtree is perfect when every word (already placed + this one + all
+    // remaining) ends up on the grid.
+    const target = this.placedWords.length + 1 + remainingWords.length
+    let best: WordPlacement[] = []
+
     // Try each candidate
     for (const candidate of candidates) {
       if (this.tryPlaceWord(word, candidate.row, candidate.col, candidate.direction)) {
+        if (this.searchBudget <= 0) {
+          // Budget exhausted: greedy mode — commit to the first valid placement.
+          return this.generateWithBacktracking(remainingWords)
+        }
+        this.searchBudget--
+
+        const checkpoint = this.placedWords.length - 1
         const result = this.generateWithBacktracking(remainingWords)
-        if (result.length >= remainingWords.length) {
+        if (result.length >= target) {
           return result
         }
+        if (result.length > best.length) {
+          best = result
+        }
 
-        // Backtrack
-        this.removeWord(this.placedWords[this.placedWords.length - 1])
+        // Backtrack: unwind everything this branch placed, not just the last word.
+        this.unwindTo(checkpoint)
       }
     }
 
-    // If we can't place this word, try without it
-    return this.generateWithBacktracking(remainingWords)
+    // Also consider skipping this word entirely.
+    const checkpoint = this.placedWords.length
+    const skipped = this.generateWithBacktracking(remainingWords)
+    if (skipped.length > best.length) {
+      best = skipped
+    }
+    this.unwindTo(checkpoint)
+
+    return best
+  }
+
+  // Remove placements from the end until only `count` remain. Placements are only
+  // ever appended, so truncating from the tail restores the exact prior grid state.
+  private unwindTo(count: number): void {
+    while (this.placedWords.length > count) {
+      this.removeWord(this.placedWords[this.placedWords.length - 1])
+    }
   }
 
   private findPlacementCandidates(word: WordEntry): PlacementCandidate[] {


### PR DESCRIPTION
Closes #76

## What
- `generateWithBacktracking` now unwinds **every** placement a rejected branch added (checkpoint-based `unwindTo`), instead of popping only the last placed word — the root cause of duplicate placements and inflated `placedWords`.
- Subtree acceptance is computed against a real target (`placed + current + remaining`) instead of the apples-to-oranges `result.length >= remainingWords.length` comparison.
- Added a deterministic search budget (expansion counter, not wall clock) so the now-correct (and more expensive) search stays bounded; when exhausted the search degrades to greedy placement and the attempt loop stops.
- A first word that cannot fit the grid is now skipped instead of aborting the whole attempt.

## Invariant tests (fail on the old code: 4 failures)
- No answer appears twice across `numbering.across + numbering.down` (3 seeds).
- `placedWords` equals the clue count and is bounded by the input size.
- Crossing letters are consistent between every clue and the final grid.
- Success only reported when the ≥90% placement threshold is genuinely met.
- Generation stays under the 2s budget (measured ~40ms for the 24-word repro).

## Note for follow-up
Honest accounting reveals the default 15×15 grid genuinely fits only ~10 of 24 medium-length words (25×25 fits all 24 in 2ms) — so realistic lists now fail loudly instead of shipping silently-wrong puzzles. That failure UX is exactly #99 (graceful generation failure / partial accept), which should be pulled into Next — it is now load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)