### PR TITLE
fix(auth): reject protocol-relative next redirect targets on login/register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to SemVer.
 
 ## [Unreleased]
 
+### Security
+- Login and register pages reject protocol-relative `next` redirect targets (`//evil.com`), closing an open-redirect phishing vector (#78)
+
 ## [0.1.0] - 2026-07-10
 
 First tracked release. Covers all functionality shipped to date — topics, word

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 import { useAppStore } from '@/lib/store'
-import type { Route } from 'next'
+import { sanitizeNextPath } from '@/lib/utils'
 
 export default function LoginPage() {
   const router = useRouter()
@@ -19,10 +19,7 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const nextUrl = (() => {
-    const param = searchParams.get('next')
-    return param && param.startsWith('/') ? (param as Route) : ('/topics' as Route)
-  })()
+  const nextUrl = sanitizeNextPath(searchParams.get('next'))
 
   useEffect(() => {
     if (sessionHydrated && user) {

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 import { useAppStore } from '@/lib/store'
-import type { Route } from 'next'
+import { sanitizeNextPath } from '@/lib/utils'
 
 export default function RegisterPage() {
   const router = useRouter()
@@ -20,10 +20,7 @@ export default function RegisterPage() {
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const nextUrl = (() => {
-    const param = searchParams.get('next')
-    return param && param.startsWith('/') ? (param as Route) : ('/topics' as Route)
-  })()
+  const nextUrl = sanitizeNextPath(searchParams.get('next'))
 
   useEffect(() => {
     if (sessionHydrated && user) {

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { cn } from '../utils'
+import { cn, sanitizeNextPath } from '../utils'
 
 describe('cn utility', () => {
   it('joins truthy class names with spaces', () => {
@@ -13,5 +13,36 @@ describe('cn utility', () => {
 
   it('handles empty input gracefully', () => {
     expect(cn()).toBe('')
+  })
+})
+
+describe('sanitizeNextPath (#78)', () => {
+  it('accepts a same-origin path', () => {
+    expect(sanitizeNextPath('/topics')).toBe('/topics')
+    expect(sanitizeNextPath('/solve/abc?tab=down')).toBe('/solve/abc?tab=down')
+  })
+
+  it('rejects protocol-relative URLs', () => {
+    expect(sanitizeNextPath('//evil.com')).toBe('/topics')
+    expect(sanitizeNextPath('//evil.com/phish')).toBe('/topics')
+  })
+
+  it('rejects backslash variants browsers normalize to //', () => {
+    expect(sanitizeNextPath('/\\evil.com')).toBe('/topics')
+  })
+
+  it('rejects absolute and scheme-based URLs', () => {
+    expect(sanitizeNextPath('https://evil.com')).toBe('/topics')
+    expect(sanitizeNextPath('javascript:alert(1)')).toBe('/topics')
+  })
+
+  it('falls back for null, empty, and relative values', () => {
+    expect(sanitizeNextPath(null)).toBe('/topics')
+    expect(sanitizeNextPath('')).toBe('/topics')
+    expect(sanitizeNextPath('topics')).toBe('/topics')
+  })
+
+  it('honours a custom fallback', () => {
+    expect(sanitizeNextPath('//evil.com', '/')).toBe('/')
   })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,16 @@
+import type { Route } from 'next'
+
 export function cn(...inputs: Array<string | false | null | undefined>): string {
   return inputs.filter(Boolean).join(' ')
+}
+
+// Sanitize a post-auth ?next= redirect target down to a same-origin path (#78).
+// A naive startsWith('/') check lets protocol-relative URLs ("//evil.com") and
+// backslash variants ("/\evil.com", which browsers normalize to "//") escape to
+// an external origin after login. Only a single-slash path is ever navigable.
+export function sanitizeNextPath(param: string | null | undefined, fallback = '/topics'): Route {
+  if (param && /^\/(?![/\\])/.test(param)) {
+    return param as Route
+  }
+  return fallback as Route
 }


### PR DESCRIPTION
Closes #78

## What
- New shared `sanitizeNextPath` helper in `src/lib/utils.ts`: a `?next=` value is only honoured when it is a single-slash same-origin path (`/^\/(?![/\\])/`). Protocol-relative (`//evil.com`) and backslash (`/\evil.com`) variants — which pass the old `startsWith('/')` guard and navigate off-origin — fall back to `/topics`.
- Login and register pages both use the helper (previously each had its own inline, vulnerable check).

## Tests
- Unit coverage for the sanitizer: same-origin paths pass; `//evil.com`, `/\evil.com`, `https://evil.com`, `javascript:` URLs, null/empty/relative values are rejected; custom fallback honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)