### PR TITLE
fix(generation): make puzzle generation independent of DB row order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to SemVer.
 ## [Unreleased]
 
 ### Fixed
+- Puzzle generation is now independent of database row order: the same list and seed reproduce the same puzzle even after rows are updated or reordered (#77)
 - Puzzle generation no longer places the same word twice or reports success for puzzles that silently dropped most of the list; placement counts and the success threshold now reflect the real grid (#76)
 
 ## [0.1.0] - 2026-07-10

--- a/src/app/api/v1/puzzles/generate/route.ts
+++ b/src/app/api/v1/puzzles/generate/route.ts
@@ -31,7 +31,10 @@ export async function POST(request: NextRequest) {
     const list = await prisma.list.findFirst({
       where: { id: validated.listId, topic: { userId } },
       include: {
-        items: true,
+        // Stable fetch order: Postgres row order is unspecified and the generator's
+        // determinism contract must not depend on it (#77). The generator also
+        // canonicalizes internally — this is defense in depth.
+        items: { orderBy: { id: 'asc' } },
       },
     })
 

--- a/src/lib/__tests__/crossword-generator.test.ts
+++ b/src/lib/__tests__/crossword-generator.test.ts
@@ -117,6 +117,41 @@ describe('CrosswordGenerator', () => {
     expect(second).toEqual(first)
   })
 
+  it('is order-independent: permuted input with the same seed yields an identical puzzle (#77)', () => {
+    // Equal-length words are the sensitive case: a length-only sort leaves their
+    // relative order up to the caller, which used to leak DB row order into the grid.
+    const equalLengthWords = [
+      { answer: 'STONE', clue: 'Rock' },
+      { answer: 'NOTES', clue: 'Reminders' },
+      { answer: 'TONES', clue: 'Sounds' },
+      { answer: 'ONSET', clue: 'Beginning' },
+      { answer: 'SETON', clue: 'Surgical thread' },
+      { answer: 'STENO', clue: 'Shorthand writer' },
+      { answer: 'CRATE', clue: 'Wooden box' },
+      { answer: 'TRACE', clue: 'Small amount' },
+    ]
+    for (const seed of ['perm-1', 'perm-2', 'perm-3', 'perm-4', 'perm-5']) {
+      const options = { gridSize: { rows: 12, cols: 12 }, seed, maxAttempts: 50 }
+      const original = new CrosswordGenerator(options).generate(equalLengthWords)
+      const permuted = new CrosswordGenerator(options).generate(
+        [...equalLengthWords].reverse(),
+      )
+      expect(permuted).toEqual(original)
+    }
+  })
+
+  it('selects the same maxWords subset regardless of input order (#77)', () => {
+    const options = {
+      gridSize: { rows: 10, cols: 10 },
+      seed: 'subset-order',
+      maxAttempts: 50,
+      maxWords: 4,
+    }
+    const original = new CrosswordGenerator(options).generate(intersectingWords)
+    const permuted = new CrosswordGenerator(options).generate([...intersectingWords].reverse())
+    expect(permuted).toEqual(original)
+  })
+
   it('is deterministic when no seed is provided', () => {
     const options = { gridSize: { rows: 10, cols: 10 }, maxAttempts: 50 }
     const first = new CrosswordGenerator(options).generate(intersectingWords)

--- a/src/lib/crossword-generator.ts
+++ b/src/lib/crossword-generator.ts
@@ -61,6 +61,18 @@ export function deriveListSeed(listId: string, items: { answer: string; clue: st
 // When exhausted, the search degrades to greedy placement (no unwinding).
 const DEFAULT_SEARCH_BUDGET = 4000
 
+// Codepoint comparison, deliberately not localeCompare: localeCompare's result
+// depends on the runtime's locale, which would make canonical ordering differ
+// between environments and break cross-machine reproducibility.
+function compareByAnswerThenClue(
+  a: { answer: string; clue: string },
+  b: { answer: string; clue: string },
+): number {
+  if (a.answer !== b.answer) return a.answer < b.answer ? -1 : 1
+  if (a.clue !== b.clue) return a.clue < b.clue ? -1 : 1
+  return 0
+}
+
 export class CrosswordGenerator {
   private rng: () => number
   private grid: (string | null)[][]
@@ -87,12 +99,17 @@ export class CrosswordGenerator {
     totalWords: number
     conflictingWords?: string[]
   } {
-    // Step 0: Select the candidate pool through the seeded RNG so word selection
-    // is as reproducible as placement (#35).
+    // Step 0: Canonicalize input order before anything touches the seeded RNG.
+    // Callers pass DB rows whose order is unspecified (and changes after updates/
+    // vacuum); "same list + same seed => same puzzle" must not depend on it (#77).
+    const canonicalWords = [...words].sort(compareByAnswerThenClue)
+
+    // Select the candidate pool through the seeded RNG so word selection is as
+    // reproducible as placement (#35).
     const pool =
-      this.maxWords && words.length > this.maxWords
-        ? this.shuffleArray(words).slice(0, this.maxWords)
-        : words
+      this.maxWords && canonicalWords.length > this.maxWords
+        ? this.shuffleArray(canonicalWords).slice(0, this.maxWords)
+        : canonicalWords
 
     // Step 1: Preprocess words
     const processedWords = this.preprocessWords(pool)
@@ -159,14 +176,19 @@ export class CrosswordGenerator {
 
   private preprocessWords(words: { answer: string; clue: string }[]): WordEntry[] {
     return words
-      .map((word) => ({
-        answer: word.answer.toUpperCase().replace(/[^A-Z]/g, ''),
-        clue: word.clue,
-        length: word.answer.length,
-        letterFreq: this.calculateLetterFrequency(word.answer),
-      }))
+      .map((word) => {
+        const answer = word.answer.toUpperCase().replace(/[^A-Z]/g, '')
+        return {
+          answer,
+          clue: word.clue,
+          length: answer.length,
+          letterFreq: this.calculateLetterFrequency(answer),
+        }
+      })
       .filter((word) => word.answer.length >= 2 && word.answer.length <= 20)
-      .sort((a, b) => b.length - a.length) // Longest words first
+      // Longest words first; ties broken by a total order so equal-length words
+      // sort identically regardless of input order (#77).
+      .sort((a, b) => b.length - a.length || compareByAnswerThenClue(a, b))
   }
 
   private calculateLetterFrequency(word: string): Map<string, number[]> {


### PR DESCRIPTION
Closes #77

## What
- `generate()` canonicalizes input order (codepoint sort by answer, then clue) before anything touches the seeded RNG — both the `maxWords` pool selection and placement now see the same sequence no matter what order the caller supplies rows in.
- `preprocessWords` breaks length ties with the same total order (deliberately not `localeCompare`, whose result is locale-dependent and would break cross-machine reproducibility).
- The generate route fetches items with `orderBy: { id: 'asc' }` as defense in depth.
- Latent bug fixed in passing: `WordEntry.length` and `letterFreq` were computed from the raw answer instead of the normalized (uppercased, A–Z-stripped) one.

## Tests
- Permuted-input determinism with 8 equal-length words (the sensitive case) across 5 seeds — fails on the old code.
- `maxWords` subset selection is order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)