### PR TITLE
fix(web): gate topics and lists pages behind auth with login redirect and loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to SemVer.
 ## [Unreleased]
 
 ### Fixed
+- Visiting your topics or lists while signed out now redirects to login (and back after signing in) instead of showing a false "No topics yet" screen; the topics page also gained a proper loading state (#82)
 - Puzzle generation no longer places the same word twice or reports success for puzzles that silently dropped most of the list; placement counts and the success threshold now reflect the real grid (#76)
 
 ## [0.1.0] - 2026-07-10

--- a/src/app/topics/[id]/lists/page.tsx
+++ b/src/app/topics/[id]/lists/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import { useAppStore } from '@/lib/store'
+import { useRequireSession } from '@/lib/useRequireSession'
 import { ListWithItemsAndTopic } from '@/types/database'
 import ListCard from '@/components/ListCard'
 import ImportListModal, { ImportListSubmission } from '@/components/ImportListModal'
@@ -42,6 +43,7 @@ export default function ListsPage() {
   const [deletingList, setDeletingList] = useState<ListWithItemsAndTopic | null>(null)
   const [isDeletingList, setIsDeletingList] = useState(false)
   const { clearSolveState, stopAutosave } = useAutosave()
+  const { isAuthenticated, isSessionPending } = useRequireSession()
 
   const fetchTopicAndLists = useCallback(
     async (id: string) => {
@@ -51,6 +53,14 @@ export default function ListsPage() {
       try {
         // Fetch topic details
         const topicResponse = await fetch(`/api/v1/topics/${id}`)
+
+        if (topicResponse.status === 401) {
+          // Session expired mid-visit — go through login rather than rendering a
+          // false empty state (#82). isLoading stays set while navigating away.
+          router.replace(`/login?next=${encodeURIComponent(`/topics/${id}/lists`)}`)
+          return
+        }
+
         const topicResult = await topicResponse.json()
 
         if (topicResult.success) {
@@ -66,21 +76,21 @@ export default function ListsPage() {
         } else {
           setError(listsResult.error?.message || 'Failed to fetch lists')
         }
+        setLoading(false)
       } catch (error) {
         setError('Network error')
         console.error('Failed to fetch data:', error)
-      } finally {
         setLoading(false)
       }
     },
-    [selectTopic, setError, setLists, setLoading],
+    [router, selectTopic, setError, setLists, setLoading],
   )
 
   useEffect(() => {
-    if (topicId) {
+    if (topicId && isAuthenticated) {
       void fetchTopicAndLists(topicId)
     }
-  }, [fetchTopicAndLists, topicId])
+  }, [fetchTopicAndLists, topicId, isAuthenticated])
 
   useEffect(() => {
     // Filter lists for current topic

--- a/src/app/topics/__tests__/page.test.tsx
+++ b/src/app/topics/__tests__/page.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import TopicsPage from '../page'
+import { useAppStore } from '@/lib/store'
+
+const replaceMock = vi.fn()
+const pushMock = vi.fn()
+// A single stable router object: components hang identity-sensitive hooks
+// (useCallback/useEffect deps) off the router, so the mock must not mint a new
+// object per render the way a naive `() => ({ ... })` would.
+const routerMock = { replace: replaceMock, push: pushMock }
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => routerMock,
+  usePathname: () => '/topics',
+}))
+
+const initialState = useAppStore.getState()
+
+describe('TopicsPage auth gate (#82)', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      ...initialState,
+      topics: [],
+      user: null,
+      sessionHydrated: false,
+      isLoading: false,
+      error: null,
+    })
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('shows a loading state (not the empty state) while the session is hydrating', () => {
+    render(<TopicsPage />)
+
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(screen.queryByText('No topics yet')).toBeNull()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('redirects an anonymous visitor to login with a next param instead of a false empty state', async () => {
+    render(<TopicsPage />)
+
+    useAppStore.setState({ sessionHydrated: true, user: null })
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith(`/login?next=${encodeURIComponent('/topics')}`)
+    })
+    expect(screen.queryByText('No topics yet')).toBeNull()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('fetches topics once authenticated', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ success: true, data: [] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TopicsPage />)
+
+    useAppStore.setState({
+      sessionHydrated: true,
+      user: { id: 'u1', email: 'user@example.com', name: null, createdAt: '' },
+    })
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/api/v1/topics')
+    })
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('redirects through login when the session expires mid-visit (401)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 401, text: async () => '' })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TopicsPage />)
+
+    useAppStore.setState({
+      sessionHydrated: true,
+      user: { id: 'u1', email: 'user@example.com', name: null, createdAt: '' },
+    })
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith(`/login?next=${encodeURIComponent('/topics')}`)
+    })
+    expect(screen.queryByText('No topics yet')).toBeNull()
+  })
+})

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAppStore } from '@/lib/store'
+import { useRequireSession } from '@/lib/useRequireSession'
 import { Topic } from '@/types/database'
 import TopicCard from '@/components/TopicCard'
 import CreateTopicModal from '@/components/CreateTopicModal'
@@ -12,6 +13,7 @@ import { Card, CardContent, CardDescription, CardTitle } from '@/components/ui/c
 export default function TopicsPage() {
   const router = useRouter()
   const { topics, setTopics, selectTopic, setLoading, setError, isLoading } = useAppStore()
+  const { isAuthenticated, isSessionPending } = useRequireSession()
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
 
   const fetchTopics = useCallback(async () => {
@@ -20,6 +22,14 @@ export default function TopicsPage() {
 
     try {
       const response = await fetch('/api/v1/topics')
+
+      if (response.status === 401) {
+        // Session expired mid-visit — send the visitor through login, never a
+        // false "no topics yet" empty state (#82). Deliberately leave isLoading
+        // set so the spinner stays up while navigation happens.
+        router.replace(`/login?next=${encodeURIComponent('/topics')}`)
+        return
+      }
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`)
@@ -41,17 +51,19 @@ export default function TopicsPage() {
       } else {
         setError(result.error?.message || 'Failed to fetch topics')
       }
+      setLoading(false)
     } catch (error) {
       setError(error instanceof Error ? error.message : 'Network error')
       console.error('Failed to fetch topics:', error)
-    } finally {
       setLoading(false)
     }
-  }, [setError, setLoading, setTopics])
+  }, [router, setError, setLoading, setTopics])
 
   useEffect(() => {
-    void fetchTopics()
-  }, [fetchTopics])
+    if (isAuthenticated) {
+      void fetchTopics()
+    }
+  }, [fetchTopics, isAuthenticated])
 
   const handleCreateTopic = async (data: {
     name: string
@@ -121,7 +133,15 @@ export default function TopicsPage() {
           </Button>
         </div>
 
-        {topics.length === 0 && !isLoading ? (
+        {isSessionPending || (isLoading && topics.length === 0) ? (
+          <div className="mt-12 flex flex-col items-center gap-4 py-12" role="status">
+            <div
+              className="h-12 w-12 animate-spin rounded-full border-2 border-primary/20 border-t-primary"
+              aria-hidden="true"
+            />
+            <p className="text-muted-foreground">Loading your topics…</p>
+          </div>
+        ) : topics.length === 0 && !isLoading ? (
           <Card className="mt-12">
             <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
               <span className="text-5xl">📚</span>

--- a/src/lib/useRequireSession.ts
+++ b/src/lib/useRequireSession.ts
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import type { Route } from 'next'
+
+import { useAppStore } from '@/lib/store'
+
+// Client-side auth gate for pages whose data requires a session (#82).
+//
+// Until the session finishes hydrating the caller should render its loading
+// state (`isSessionPending`); once hydrated, an anonymous visitor is redirected
+// to login with a `next` param pointing back at the current page — mirroring the
+// solve page's behaviour instead of letting fetches 401 into a false empty state.
+export function useRequireSession() {
+  const router = useRouter()
+  const pathname = usePathname()
+  const user = useAppStore((state) => state.user)
+  const sessionHydrated = useAppStore((state) => state.sessionHydrated)
+
+  useEffect(() => {
+    if (sessionHydrated && !user) {
+      router.replace(`/login?next=${encodeURIComponent(pathname ?? '/')}` as Route)
+    }
+  }, [sessionHydrated, user, router, pathname])
+
+  return {
+    user,
+    // True while we cannot yet render data: session unknown, or redirect pending.
+    isSessionPending: !sessionHydrated || !user,
+    isAuthenticated: sessionHydrated && user !== null,
+  }
+}


### PR DESCRIPTION
Closes #82

## What
- New `useRequireSession` hook: once the session hydrates, an anonymous visitor is redirected to `/login?next=<current page>` — mirroring the solve page's existing behaviour. Data fetches only start once authenticated.
- Applied to `/topics` and `/topics/[id]/lists` (the lists page had the same gap).
- `/topics` gained the missing loading state (spinner with `role="status"`), shown while the session hydrates or the first fetch is in flight — the bare grid/empty state no longer flashes.
- Mid-visit session expiry (401 from the API) also redirects through login; `isLoading` deliberately stays set during that navigation so the false "No topics yet" state can never appear.

## Tests
Page tests for the gate: loading state while hydrating (no fetch fired), anonymous → `router.replace('/login?next=%2Ftopics')`, authenticated → fetch fires, 401 mid-visit → redirect with no false empty state.

Related: #36 owns rendering the store error on these pages; deliberately not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)