### PR TITLE
feat(generation): accept partial puzzles with unplaced-word review and grid-size ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to SemVer.
 
 ## [Unreleased]
 
+### Added
+- Puzzle generation now grows the grid (15→17→19) when a list doesn't fit, accepts partial puzzles instead of failing outright, and the solve screen discloses any words that didn't fit with a dismissible notice (#99)
+
 ### Fixed
 - Puzzle generation is now independent of database row order: the same list and seed reproduce the same puzzle even after rows are updated or reordered (#77)
 - Puzzle generation no longer places the same word twice or reports success for puzzles that silently dropped most of the list; placement counts and the success threshold now reflect the real grid (#76)

--- a/docs/puzzle-generation-flow.md
+++ b/docs/puzzle-generation-flow.md
@@ -14,13 +14,22 @@ Describe how the system generates a new crossword from a list.
 
 ## Step-by-Step
 1. Client posts `{ listId, seed?, gridSize? }` to `/api/v1/puzzles/generate`.
-2. API fetches list + items from Prisma.
+2. API fetches list + items from Prisma (`orderBy: id` — see Determinism below).
 3. API resolves the seed (see Seed Contract below).
-4. `CrosswordGenerator` selects up to 150 items via its seeded RNG, preprocesses
-   answers, and searches for a placement — the same RNG drives selection and placement.
-5. On success, API stores `grid`, `numbering`, `settings` JSON blobs and the resolved seed.
-6. API returns `{ puzzleId, seed, metrics }`.
-7. Client navigates to `/solve/:puzzleId`.
+4. `CrosswordGenerator` canonicalizes item order, selects up to 150 items via its
+   seeded RNG, preprocesses answers, and searches for a placement — the same RNG
+   drives selection and placement.
+5. **Grid-size ladder (#99)**: when the client does not pin a `gridSize`, the API
+   tries 15×15, 17×17, then 19×19 and keeps the result that places the most words
+   (stopping early once every word fits). An explicit `gridSize` is honoured exactly.
+6. **Partial acceptance (#99)**: a puzzle is stored as long as at least 2 words
+   placed. Words that did not fit are returned as `unplacedWords` and persisted in
+   the puzzle `settings` so the solve UI can disclose them. Fewer than 2 placeable
+   words -> 422 with the full unplaced list and a suggestion to split the list.
+7. API stores `grid`, `numbering`, `settings` JSON blobs and the resolved seed.
+8. API returns `{ puzzleId, grid, numbering, seed, placedWords, totalWords, unplacedWords }`.
+9. Client navigates to `/solve/:puzzleId`; the solve page shows a dismissible
+   notice when `unplacedWords` is non-empty.
 
 ## Seed Contract (#35, ADR-006)
 - Generation is fully deterministic: the same `(list content, seed, gridSize)` always
@@ -54,8 +63,10 @@ flowchart TD
 
 ## Failure Modes
 - Missing session -> 401.
-- List not found -> 404 / error payload.
-- Generator failure -> 400/500 with message.
+- List not found (or not owned by the caller) -> 404.
+- Fewer than 2 words can be placed together -> 422 with
+  `details.unplacedWords` naming every word that did not fit (#99).
+- Invalid request body -> 400; unexpected errors -> 500.
 
 ## Key Files
 - `src/app/api/v1/puzzles/generate/route.ts`

--- a/src/app/api/v1/puzzles/generate/__tests__/route.test.ts
+++ b/src/app/api/v1/puzzles/generate/__tests__/route.test.ts
@@ -89,4 +89,109 @@ describe('POST /api/v1/puzzles/generate', () => {
     const response = await POST(makeRequest({ listId: LIST_ID }))
     expect(response.status).toBe(404)
   })
+
+  describe('partial acceptance (#99)', () => {
+    // Realistic vocab: enough words that a 15x15 grid cannot fit them all, so the
+    // route must either grow the grid or accept a partial puzzle — never fail.
+    const bigList = [
+      'GLUCOSE',
+      'MITOCHONDRIA',
+      'RIBOSOME',
+      'NUCLEUS',
+      'CYTOPLASM',
+      'MEMBRANE',
+      'ENZYME',
+      'PROTEIN',
+      'CHLOROPLAST',
+      'OSMOSIS',
+      'DIFFUSION',
+      'PHOTOSYNTHESIS',
+      'RESPIRATION',
+      'BACTERIA',
+      'VIRUS',
+      'GENOME',
+      'CHROMOSOME',
+      'MEIOSIS',
+      'MITOSIS',
+      'ORGANELLE',
+      'VACUOLE',
+      'LYSOSOME',
+      'PEPTIDE',
+      'HORMONE',
+    ].map((answer, i) => ({ answer, clue: `Term ${i + 1}` }))
+
+    it('accepts a realistic 24-word list instead of failing, disclosing any unplaced words', async () => {
+      vi.mocked(prisma.list.findFirst).mockResolvedValue({
+        id: LIST_ID,
+        items: bigList,
+      } as Awaited<ReturnType<typeof prisma.list.findFirst>>)
+
+      const response = await POST(makeRequest({ listId: LIST_ID, seed: 'classroom' }))
+      const result = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(result.success).toBe(true)
+      expect(result.data.placedWords).toBeGreaterThanOrEqual(2)
+      expect(result.data.placedWords + result.data.unplacedWords.length).toBe(bigList.length)
+
+      // The unplaced list is persisted so the solve UI can disclose it on reload.
+      const settings = JSON.parse(
+        vi.mocked(prisma.puzzle.create).mock.calls[0][0].data.settings as string,
+      )
+      expect(settings.unplacedWords).toEqual(result.data.unplacedWords)
+    })
+
+    it('is deterministic across the grid-size ladder', async () => {
+      vi.mocked(prisma.list.findFirst).mockResolvedValue({
+        id: LIST_ID,
+        items: bigList,
+      } as Awaited<ReturnType<typeof prisma.list.findFirst>>)
+
+      const body = { listId: LIST_ID, seed: 'ladder-seed' }
+      const first = await (await POST(makeRequest(body))).json()
+      const second = await (await POST(makeRequest(body))).json()
+
+      expect(second.data.grid).toEqual(first.data.grid)
+      expect(second.data.numbering).toEqual(first.data.numbering)
+      expect(second.data.unplacedWords).toEqual(first.data.unplacedWords)
+    })
+
+    it('honours an explicitly requested grid size without laddering', async () => {
+      vi.mocked(prisma.list.findFirst).mockResolvedValue({
+        id: LIST_ID,
+        items: bigList,
+      } as Awaited<ReturnType<typeof prisma.list.findFirst>>)
+
+      const response = await POST(
+        makeRequest({ listId: LIST_ID, seed: 's', gridSize: { rows: 15, cols: 15 } }),
+      )
+      const result = await response.json()
+
+      expect(result.success).toBe(true)
+      const settings = JSON.parse(
+        vi.mocked(prisma.puzzle.create).mock.calls[0][0].data.settings as string,
+      )
+      expect(settings.gridSize).toEqual({ rows: 15, cols: 15 })
+      expect(result.data.grid.size).toEqual({ rows: 15, cols: 15 })
+    })
+
+    it('still fails with the unplaced list when fewer than two words can cross', async () => {
+      vi.mocked(prisma.list.findFirst).mockResolvedValue({
+        id: LIST_ID,
+        // No shared letters: at most one word can ever be placed.
+        items: [
+          { answer: 'AAA', clue: 'First' },
+          { answer: 'BBB', clue: 'Second' },
+        ],
+      } as Awaited<ReturnType<typeof prisma.list.findFirst>>)
+
+      const response = await POST(makeRequest({ listId: LIST_ID, seed: 'no-crossings' }))
+      const result = await response.json()
+
+      expect(response.status).toBe(422)
+      expect(result.success).toBe(false)
+      expect(result.error.details.unplacedWords.length).toBeGreaterThan(0)
+      expect(vi.mocked(prisma.puzzle.create)).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/app/api/v1/puzzles/generate/route.ts
+++ b/src/app/api/v1/puzzles/generate/route.ts
@@ -23,9 +23,6 @@ export async function POST(request: NextRequest) {
     const userId = session.user.id
     const body = await request.json()
     const validated = GeneratePuzzleSchema.parse(body)
-    const gridSize = validated.gridSize
-      ? { rows: validated.gridSize.rows ?? 15, cols: validated.gridSize.cols ?? 15 }
-      : { rows: 15, cols: 15 }
 
     // Fetch list with items
     const list = await prisma.list.findFirst({
@@ -63,25 +60,47 @@ export async function POST(request: NextRequest) {
     // drives both word selection (up to 150 items) and placement.
     const seed = validated.seed || deriveListSeed(list.id, items)
 
-    const generator = new CrosswordGenerator({
-      gridSize,
-      seed,
-      maxAttempts: 300,
-      maxWords: 150,
-    })
+    // When the caller pins a grid size we honour it exactly. Otherwise walk a
+    // fixed ladder of sizes: many realistic lists cannot fully fit on 15x15, and
+    // a bigger grid beats silently dropping words (#99). The ladder is a pure
+    // function of (items, seed), so the determinism contract (ADR-006) holds.
+    const gridSizes = validated.gridSize
+      ? [{ rows: validated.gridSize.rows ?? 15, cols: validated.gridSize.cols ?? 15 }]
+      : [15, 17, 19].map((size) => ({ rows: size, cols: size }))
 
-    const result = generator.generate(items)
+    let best: { result: ReturnType<CrosswordGenerator['generate']>; gridSize: (typeof gridSizes)[0] } | null =
+      null
+    for (const gridSize of gridSizes) {
+      const generator = new CrosswordGenerator({
+        gridSize,
+        seed,
+        maxAttempts: 300,
+        maxWords: 150,
+      })
+      const result = generator.generate(items)
+      if (!best || result.placedWords > best.result.placedWords) {
+        best = { result, gridSize }
+      }
+      if (result.placedWords === result.totalWords) {
+        break // everything fits — no reason to grow the grid further
+      }
+    }
 
-    if (!result.success) {
+    const { result, gridSize } = best!
+
+    // A puzzle needs at least two crossing words to be worth solving. Below that,
+    // fail with the full unplaced list so the author can fix the source list.
+    if (!result.grid || !result.numbering || result.placedWords < 2) {
       return NextResponse.json(
         {
           success: false,
           error: {
-            message: 'Failed to generate puzzle',
+            message:
+              'These words could not be placed together — they share too few letters. Try splitting the list or adding words with more overlap.',
             details: {
               placedWords: result.placedWords,
               totalWords: result.totalWords,
-              conflictingWords: result.conflictingWords,
+              unplacedWords: result.unplacedWords,
             },
           },
         },
@@ -89,7 +108,8 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // Save puzzle to database
+    // Save puzzle to database. A partial puzzle (some words unplaced) is accepted;
+    // the unplaced list is persisted so the solve UI can disclose it (#99).
     const puzzle = await prisma.puzzle.create({
       data: {
         listId: validated.listId,
@@ -101,6 +121,7 @@ export async function POST(request: NextRequest) {
           checkMode: 'word',
           symmetry: false,
           allowHyphens: false,
+          unplacedWords: result.unplacedWords,
         }),
       },
     })
@@ -114,6 +135,7 @@ export async function POST(request: NextRequest) {
         seed: puzzle.seed,
         placedWords: result.placedWords,
         totalWords: result.totalWords,
+        unplacedWords: result.unplacedWords,
       },
     })
   } catch (error) {

--- a/src/app/solve/[id]/page.tsx
+++ b/src/app/solve/[id]/page.tsx
@@ -32,6 +32,9 @@ export default function SolvePage() {
   } = useAppStore()
 
   const [selectedTab, setSelectedTab] = useState<'across' | 'down'>('across')
+  // Tracks which puzzle's unplaced-words notice was dismissed, so the notice
+  // reappears when a different (partial) puzzle loads.
+  const [dismissedUnplacedFor, setDismissedUnplacedFor] = useState<string | null>(null)
   const [autosaveMeta, setAutosaveMeta] = useState<{
     lastLocalSave: Date | null
     lastServerSave: Date | null
@@ -132,6 +135,9 @@ export default function SolvePage() {
               numbering: puzzleData.numbering,
               seed: puzzleData.seed,
               listId: puzzleData.list.id,
+              unplacedWords: Array.isArray(puzzleData.settings?.unplacedWords)
+                ? puzzleData.settings.unplacedWords
+                : undefined,
             })
 
             const remoteState = result.data.state
@@ -432,6 +438,30 @@ export default function SolvePage() {
         isGenerating={useAppStore.getState().isLoading}
         autosaveStatus={autosaveStatus}
       />
+
+      {currentPuzzle.unplacedWords &&
+        currentPuzzle.unplacedWords.length > 0 &&
+        dismissedUnplacedFor !== currentPuzzle.id && (
+          <div className="container mx-auto px-4 pt-4" role="status">
+            <div className="flex items-start justify-between gap-4 rounded-md border border-warning-border bg-warning-muted px-4 py-3 text-sm text-warning">
+              <p>
+                {currentPuzzle.unplacedWords.length === 1
+                  ? '1 word from this list didn’t fit the grid: '
+                  : `${currentPuzzle.unplacedWords.length} words from this list didn’t fit the grid: `}
+                <span className="font-semibold">{currentPuzzle.unplacedWords.join(', ')}</span>.
+                Generate a new puzzle for another mix, or split the list so every word fits.
+              </p>
+              <button
+                type="button"
+                onClick={() => setDismissedUnplacedFor(currentPuzzle.id)}
+                aria-label="Dismiss unplaced words notice"
+                className="rounded p-1 leading-none text-warning transition-colors hover:bg-warning-border/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+        )}
 
       <div className="container mx-auto flex w-full flex-1 flex-col gap-6 px-4 pb-10 pt-6">
         <SolveSurface

--- a/src/lib/__tests__/crossword-generator.test.ts
+++ b/src/lib/__tests__/crossword-generator.test.ts
@@ -45,7 +45,7 @@ describe('CrosswordGenerator', () => {
         expect(gridLetters.has(letter)).toBe(true)
       }
     } else {
-      expect(result.conflictingWords).toBeDefined()
+      expect(result.unplacedWords.length).toBeGreaterThan(0)
     }
   })
 
@@ -79,11 +79,35 @@ describe('CrosswordGenerator', () => {
 
     expect(result.success).toBe(false)
     expect(result.placedWords).toBeLessThan(nonIntersectingWords.length)
-    expect(result.conflictingWords).toBeDefined()
+    expect(result.unplacedWords.length).toBe(nonIntersectingWords.length - result.placedWords)
     const upperAnswers = nonIntersectingWords.map((w) => w.answer.toUpperCase())
-    for (const word of result.conflictingWords ?? []) {
+    for (const word of result.unplacedWords) {
       expect(upperAnswers).toContain(word)
     }
+  })
+
+  it('returns a usable partial grid with the full unplaced list when below the threshold (#99)', () => {
+    const generator = new CrosswordGenerator({
+      gridSize: { rows: 6, cols: 6 },
+      seed: 'partial-accept',
+      maxAttempts: 10,
+    })
+
+    const result = generator.generate(nonIntersectingWords)
+
+    expect(result.success).toBe(false)
+    expect(result.placedWords).toBeGreaterThan(0)
+    expect(result.grid).toBeDefined()
+    expect(result.numbering).toBeDefined()
+
+    const placedAnswers = [
+      ...(result.numbering?.across ?? []),
+      ...(result.numbering?.down ?? []),
+    ].map((clue) => clue.answer)
+    expect(placedAnswers.length).toBe(result.placedWords)
+    // Placed and unplaced partition the input exactly.
+    const all = [...placedAnswers, ...result.unplacedWords].sort()
+    expect(all).toEqual(nonIntersectingWords.map((w) => w.answer.toUpperCase()).sort())
   })
 
   it('returns failure metadata gracefully when no words are supplied', () => {
@@ -235,7 +259,7 @@ describe('CrosswordGenerator placement invariants (#76)', () => {
     if (result.success) {
       expect(distinctPlaced).toBeGreaterThanOrEqual(Math.floor(biologyWords.length * 0.9))
     } else {
-      expect(result.conflictingWords).toBeDefined()
+      expect(result.unplacedWords.length).toBeGreaterThan(0)
     }
   })
 

--- a/src/lib/crossword-generator.ts
+++ b/src/lib/crossword-generator.ts
@@ -92,12 +92,16 @@ export class CrosswordGenerator {
   }
 
   public generate(words: { answer: string; clue: string }[]): {
+    // True when the placement threshold (>=90% of the pool) was met. A partial
+    // grid/numbering is still returned below the threshold whenever at least one
+    // word placed — the caller decides whether to accept it (#99).
     success: boolean
     grid?: CrosswordGrid
     numbering?: CrosswordNumbering
     placedWords: number
     totalWords: number
-    conflictingWords?: string[]
+    // Every pool word that did not make it onto the grid, in canonical order.
+    unplacedWords: string[]
   } {
     // Step 0: Canonicalize input order before anything touches the seeded RNG.
     // Callers pass DB rows whose order is unspecified (and changes after updates/
@@ -114,7 +118,12 @@ export class CrosswordGenerator {
     // Step 1: Preprocess words
     const processedWords = this.preprocessWords(pool)
     if (processedWords.length === 0) {
-      return { success: false, placedWords: 0, totalWords: pool.length }
+      return {
+        success: false,
+        placedWords: 0,
+        totalWords: pool.length,
+        unplacedWords: pool.map((word) => word.answer.toUpperCase()),
+      }
     }
 
     // Step 2: Try generation with multiple attempts
@@ -149,28 +158,30 @@ export class CrosswordGenerator {
 
     this.placedWords = bestResult
     const successRate = bestResult.length / pool.length
+    const unplacedWords = this.findUnplacedWords(processedWords, bestResult)
 
-    if (successRate < 0.9) {
-      const conflictingWords = this.findConflictingWords(processedWords, bestResult)
+    if (bestResult.length === 0) {
       return {
         success: false,
-        placedWords: bestResult.length,
+        placedWords: 0,
         totalWords: pool.length,
-        conflictingWords,
+        unplacedWords,
       }
     }
 
-    // Step 3: Create final grid and numbering
+    // Step 3: Create final grid and numbering — also for partial results, so the
+    // caller can accept an incomplete puzzle with an explicit unplaced list (#99).
     this.rebuildGrid(bestResult)
     const finalGrid = this.createFinalGrid()
     const numbering = this.generateNumbering(bestResult)
 
     return {
-      success: true,
+      success: successRate >= 0.9,
       grid: finalGrid,
       numbering,
       placedWords: bestResult.length,
       totalWords: pool.length,
+      unplacedWords,
     }
   }
 
@@ -596,11 +607,8 @@ export class CrosswordGenerator {
     return shuffled
   }
 
-  private findConflictingWords(allWords: WordEntry[], placedWords: WordPlacement[]): string[] {
+  private findUnplacedWords(allWords: WordEntry[], placedWords: WordPlacement[]): string[] {
     const placed = new Set(placedWords.map((p) => p.word))
-    return allWords
-      .filter((w) => !placed.has(w.answer))
-      .map((w) => w.answer)
-      .slice(0, 5) // Return up to 5 conflicting words
+    return allWords.filter((w) => !placed.has(w.answer)).map((w) => w.answer)
   }
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -19,6 +19,9 @@ interface AppState {
     numbering: CrosswordNumbering
     seed: string
     listId: string
+    // Words from the source list that did not fit on the grid (#99); surfaced to
+    // the solver so a partial puzzle is never silently presented as complete.
+    unplacedWords?: string[]
   } | null
 
   // Solve state

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -24,7 +24,7 @@ import {
   RegisterSchema,
   LoginSchema,
 } from '@/lib/validation'
-import type { CrosswordGrid, CrosswordNumbering, PuzzleSettings } from '@/types/crossword'
+import type { CrosswordGrid, CrosswordNumbering } from '@/types/crossword'
 
 // --- Request types (derived from Zod schemas) ---
 
@@ -43,7 +43,11 @@ export interface GeneratePuzzleResponse {
   puzzleId: string
   grid: CrosswordGrid
   numbering: CrosswordNumbering
-  settings: PuzzleSettings
+  seed: string
+  placedWords: number
+  totalWords: number
+  // Words that did not fit the grid when a partial puzzle was accepted (#99).
+  unplacedWords: string[]
 }
 
 export interface ExportListResponse {

--- a/src/types/crossword.ts
+++ b/src/types/crossword.ts
@@ -44,6 +44,8 @@ export interface PuzzleSettings {
   checkMode: 'off' | 'letter' | 'word' | 'full'
   symmetry: boolean
   allowHyphens: boolean
+  // Words that did not fit when this (partial) puzzle was accepted (#99).
+  unplacedWords?: string[]
 }
 
 // Generation types
@@ -68,7 +70,7 @@ export interface GenerationResult {
   puzzle?: CrosswordPuzzle
   placedWords: number
   totalWords: number
-  conflictingWords?: string[]
+  unplacedWords?: string[]
   error?: string
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,6 +24,10 @@ const config: Config = {
         border: '#e5e7eb',
         input: '#e5e7eb',
         ring: '#2563eb',
+        // Non-blocking caution notices (e.g. partial-puzzle disclosure, #99).
+        warning: '#92400e',
+        'warning-muted': '#fef3c7',
+        'warning-border': '#fcd34d',
         gray: {
           50: '#f9fafb',
           100: '#f3f4f6',


### PR DESCRIPTION
Closes #99

Pulled into this batch because #76's honest accounting revealed the default 15×15 grid genuinely fits only ~10 of 24 medium-length words — without this, realistic lists hard-fail with a 422.

## What
- **Grid-size ladder**: when the client doesn't pin a `gridSize`, the route tries 15×15 → 17×17 → 19×19 and keeps the result placing the most words, stopping early once everything fits. A pure function of (items, seed) — the ADR-006 determinism contract holds. An explicit `gridSize` is honoured exactly (composable with #22).
- **Partial acceptance**: a puzzle is stored as long as ≥2 words placed. `unplacedWords` (full list, canonical order) is returned and persisted in the puzzle `settings`.
- **Solve UI disclosure**: a dismissible warning notice (new `warning` theme tokens, `role="status"`) names the words that didn't fit, so a partial puzzle is never silently presented as complete. Notice re-appears per puzzle.
- **Honest hard-fail**: <2 placeable words → 422 with the full unplaced list and a suggestion to split the list (friendly message, no jargon).
- Generator now returns grid+numbering for partial results and `unplacedWords` (replaces the capped `conflictingWords`); `GeneratePuzzleResponse` in `src/types/api.ts` corrected to the real route shape.

## Tests (155 passing)
- Generator: partial grid + placed/unplaced partition the input exactly.
- Route: 24-word realistic list now succeeds (was 422), unplaced list persisted in settings; ladder determinism (two calls → identical grid/numbering/unplacedWords); explicit gridSize honoured without laddering; <2 crossings → 422 with unplaced details and no DB write.

Docs: `docs/puzzle-generation-flow.md` updated (ladder, partial accept, failure modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)