### PR TITLE
fix(lists): reject import answers with characters outside A-Z instead of silently stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to SemVer.
 ## [Unreleased]
 
 ### Fixed
+- Importing a list with an answer containing characters outside A–Z (accents, digits, hyphens, spaces) now fails with an error naming the word, instead of silently stripping characters and corrupting the list (#17)
 - Puzzle generation is now independent of database row order: the same list and seed reproduce the same puzzle even after rows are updated or reordered (#77)
 - Puzzle generation no longer places the same word twice or reports success for puzzles that silently dropped most of the list; placement counts and the success threshold now reflect the real grid (#76)
 

--- a/docs/list-import-maintenance-flow.md
+++ b/docs/list-import-maintenance-flow.md
@@ -17,8 +17,12 @@ Detail how lists are imported, validated, and maintained (create/update).
 ## Step-by-Step (Import)
 1. Client validates JSON with `validateListJSON`.
 2. Client posts to `/api/v1/lists` or `/api/v1/lists/import`.
-3. API normalizes answers and enforces uniqueness.
-4. API creates list + items inside a transaction.
+3. API validates answers against the allowed-character policy (#17): letters
+   A–Z only after uppercasing. Any other character (accent, digit, hyphen,
+   space) **denies the whole import** with a 400 whose details name the
+   offending word — answers are never silently stripped. Uniqueness is
+   enforced on the uppercased values.
+4. API creates list + items inside a transaction (case normalization only).
 5. API returns enriched list data for UI refresh.
 
 ```mermaid
@@ -54,7 +58,8 @@ flowchart TD
 
 ## Failure Modes
 - Invalid JSON format -> 400 with validation errors.
-- Duplicate answers after normalization -> 400.
+- Answer containing a character outside A–Z -> 400 naming the word; nothing is imported (#17).
+- Duplicate answers after uppercasing -> 400.
 - Missing session -> 401.
 
 ## Key Files

--- a/docs/specs/CROSSWISE_SPEC.md
+++ b/docs/specs/CROSSWISE_SPEC.md
@@ -202,13 +202,13 @@ Authentication: cookie `crosswise_session` required for most endpoints.
 - `POST /api/v1/lists`
   - Auth required.
   - Body: `{ topicId, name, items[] }` where items are `{answer, clue, note?, difficulty?}`.
-  - Normalizes answers to uppercase A–Z.
+  - Uppercases answers; rejects any answer containing a character outside A–Z (400 naming the word; nothing is created, #17).
   - Errors: 404 (topic not found), 500.
 
 - `PUT /api/v1/lists/:id`
   - Auth required.
   - Body: `{ name, version?, items[] }` where items can include `id`.
-  - Deletes items missing in payload. Normalizes answers and ensures uniqueness post-normalization.
+  - Deletes items missing in payload. Uppercases answers (disallowed characters are rejected, #17) and ensures uniqueness.
   - Errors: 400 (validation), 404, 500.
 
 - `POST /api/v1/lists/import`
@@ -258,7 +258,7 @@ Authentication: cookie `crosswise_session` required for most endpoints.
   - `reset` clears solve state + completedAt; `delete` removes solves.
 
 ## Validation & Normalization Rules
-- **List item answers:** normalized to uppercase A–Z; length 2–20.
+- **List item answers:** uppercased; must contain only letters A–Z (accents, digits, hyphens, spaces are rejected with an error naming the word — never silently stripped, #17); length 2–20.
 - **Clue length:** 3–200 chars.
 - **Import list items:** min 5, max 250 (optimal up to 150 for generation).
 - **Difficulty:** accepts numeric 1–5 or string `EASY|MEDIUM|HARD`; mapped to enum.

--- a/docs/uat/UAT_CW-17.md
+++ b/docs/uat/UAT_CW-17.md
@@ -1,0 +1,31 @@
+# UAT — CW-17: Import answers must contain only allowed characters
+
+- Work Item: CW-17 (#17)
+- Feature / Workflow: List import answer-character validation (fail-closed)
+- Environment: local / preview
+
+## Behavior Under Test
+
+Importing a word list (pasted JSON or uploaded file) where any answer contains a
+character outside the letters A–Z (after uppercasing) must **deny the whole
+import** with a friendly error that names the offending word. Nothing may be
+silently stripped or partially imported.
+
+## Acceptance Scenarios
+
+| # | Scenario | Steps | Expected |
+|---|---|---|---|
+| 1 | Happy path | Import a list whose answers are all letters (any case) | Import succeeds; answers stored uppercased; item count matches |
+| 2 | Accented character | Include `CAFÉ` in an otherwise valid list | 400 / modal error naming `CAFÉ`, mentioning letters A–Z; nothing created |
+| 3 | Digit / hyphen / space | Include `WORD3`, `SEA-LION`, or `FENNEC FOX` | Same as #2, naming the exact word |
+| 4 | No silent strip (regression) | Import `CAF-É3` | Import denied; **no** list item `CAF` appears anywhere |
+| 5 | Whole-import denial | 9 valid words + 1 invalid | Zero items created; error names only the invalid word |
+| 6 | Accessibility | Trigger a validation error in the Import modal | Error list is announced (role="alert"), readable, and keyboard-reachable |
+| 7 | Auth boundary | Call `POST /api/v1/lists/import` without a session | 401 before any validation/write |
+
+## Notes
+
+- The allowed-character rule lives in `src/lib/validation.ts`
+  (`ANSWER_ALLOWED_PATTERN`, `AnswerSchema`) and is shared by client and server;
+  CSV import (#31) must reuse the same helper.
+- Case is the only permitted normalization (`normalizeAnswer` uppercases only).

--- a/src/app/api/v1/lists/import/__tests__/route.test.ts
+++ b/src/app/api/v1/lists/import/__tests__/route.test.ts
@@ -140,4 +140,51 @@ describe('/api/v1/lists/import POST handler', () => {
     expect(response.status).toBe(401)
     expect(topicFindFirst).not.toHaveBeenCalled()
   })
+
+  describe('answer character validation (#17)', () => {
+    const requestWith = (items: Array<{ answer: string; clue: string }>) =>
+      new NextRequest('http://localhost/api/v1/lists/import', {
+        method: 'POST',
+        body: JSON.stringify({ ...importPayload, items }),
+        headers: {
+          'content-type': 'application/json',
+          cookie: `${SESSION_COOKIE_NAME}=token-123`,
+        },
+      })
+
+    it('denies the whole import when any answer has a disallowed character, naming the word', async () => {
+      const items = [
+        ...importPayload.items.slice(0, 4),
+        { answer: 'CAFÉ-3', clue: 'Contains an accent, a hyphen, and a digit' },
+      ]
+
+      const response = await POST(requestWith(items))
+      const result = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(result.success).toBe(false)
+      const answerError = (result.error.details as Array<{ field: string; message: string }>).find(
+        (detail) => detail.field.endsWith('answer'),
+      )
+      expect(answerError?.message).toContain('CAFÉ-3')
+      expect(answerError?.message).toContain("aren't letters A–Z")
+
+      // Nothing was created: the invalid word denies the entire import.
+      expect(prismaTransaction).not.toHaveBeenCalled()
+      expect(topicCreate).not.toHaveBeenCalled()
+    })
+
+    it('no longer writes silently-stripped answers', async () => {
+      // "CAF-É3" used to be written as "CAF"; assert no write happens at all.
+      const response = await POST(
+        requestWith([
+          ...importPayload.items.slice(0, 4),
+          { answer: 'CAF-É3', clue: 'Would previously import as CAF' },
+        ]),
+      )
+
+      expect(response.status).toBe(400)
+      expect(prismaTransaction).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/components/ImportListModal.tsx
+++ b/src/components/ImportListModal.tsx
@@ -174,7 +174,7 @@ export default function ImportListModal({
           </div>
 
           {errors.length > 0 && (
-            <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3">
+            <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3" role="alert">
               <h4 className="mb-1 text-sm font-medium text-red-800">Validation Errors:</h4>
               <ul className="list-inside list-disc text-sm text-red-700">
                 {errors.map((error, index) => (
@@ -188,7 +188,7 @@ export default function ImportListModal({
             <h4 className="mb-1 text-sm font-medium text-blue-800">Expected Format:</h4>
             <ul className="list-inside list-disc text-xs text-blue-700">
               <li>5-150 items for best results (sweet spot: 10-150)</li>
-              <li>Answers: 2-20 characters, A-Z only (auto-converted)</li>
+              <li>Answers: 2-20 characters, letters A-Z only (accents, digits, and punctuation are rejected)</li>
               <li>Clues: 3-200 characters</li>
               <li>Optional: note, difficulty (1-5)</li>
             </ul>

--- a/src/components/__tests__/ImportListModal.test.tsx
+++ b/src/components/__tests__/ImportListModal.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import ImportListModal from '../ImportListModal'
+import type { Topic } from '@/types/database'
+
+const topics = [
+  {
+    id: 'ctopic1234567890123456789',
+    name: 'Animals',
+    icon: '🦊',
+  } as unknown as Topic,
+]
+
+const validItems = [
+  { answer: 'otter', clue: 'Playful river mammal' },
+  { answer: 'badger', clue: 'Builds complex burrows underground' },
+  { answer: 'panda', clue: 'Eats mostly bamboo' },
+  { answer: 'fennec', clue: 'Desert fox with big ears' },
+  { answer: 'weasel', clue: 'Slim, quick mustelid' },
+]
+
+function renderModal(onSubmit = vi.fn()) {
+  render(
+    <ImportListModal isOpen={true} onClose={vi.fn()} onSubmit={onSubmit} topics={topics} />,
+  )
+  return onSubmit
+}
+
+function fillAndSubmit(payload: object) {
+  fireEvent.change(screen.getByRole('combobox'), {
+    target: { value: topics[0].id },
+  })
+  fireEvent.change(screen.getByPlaceholderText('Paste JSON data or upload file...'), {
+    target: { value: JSON.stringify(payload) },
+  })
+  fireEvent.submit(screen.getByRole('button', { name: /import list/i }))
+}
+
+describe('ImportListModal answer validation (#17)', () => {
+  it('shows a word-naming error and does not submit when an answer has disallowed characters', async () => {
+    const onSubmit = renderModal()
+
+    fillAndSubmit({
+      topic: 'Animals',
+      name: 'Wildlife',
+      items: [...validItems.slice(0, 4), { answer: 'CAFÉ-3', clue: 'Invalid characters here' }],
+    })
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('CAFÉ-3')
+    expect(alert.textContent).toContain("aren't letters A–Z")
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits a fully valid list unchanged', async () => {
+    const onSubmit = renderModal()
+
+    fillAndSubmit({ topic: 'Animals', name: 'Wildlife', items: validItems })
+
+    expect(await screen.queryByRole('alert')).toBeNull()
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    const submitted = onSubmit.mock.calls[0][0]
+    expect(submitted.items.map((item: { answer: string }) => item.answer)).toEqual([
+      'OTTER',
+      'BADGER',
+      'PANDA',
+      'FENNEC',
+      'WEASEL',
+    ])
+  })
+})

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -8,15 +8,15 @@ import {
 } from '../validation'
 
 describe('validation helpers', () => {
-  it('validates and normalizes a well-formed list payload', () => {
+  it('validates and uppercases a well-formed list payload', () => {
     const payload = {
       topic: 'Animals',
       name: 'Mammals',
       version: 1,
       items: [
         { answer: 'otter', clue: 'Playful river mammal', note: 'Loves water' },
-        { answer: 'Sea-lion', clue: 'Barks loudly on the shore' },
-        { answer: 'Fennec Fox', clue: 'Desert fox with big ears' },
+        { answer: 'Sealion', clue: 'Barks loudly on the shore' },
+        { answer: 'Fennec', clue: 'Desert fox with big ears' },
         { answer: 'Badger', clue: 'Builds complex burrows underground' },
         { answer: 'Panda', clue: 'Eats mostly bamboo', difficulty: 'MEDIUM' },
       ],
@@ -27,10 +27,50 @@ describe('validation helpers', () => {
     expect(result.data?.items.map((item) => item.answer)).toEqual([
       'OTTER',
       'SEALION',
-      'FENNECFOX',
+      'FENNEC',
       'BADGER',
       'PANDA',
     ])
+  })
+
+  it('rejects answers with disallowed characters and names the offending word (#17)', () => {
+    const base = [
+      { answer: 'otter', clue: 'Playful river mammal' },
+      { answer: 'Badger', clue: 'Builds complex burrows underground' },
+      { answer: 'Panda', clue: 'Eats mostly bamboo' },
+      { answer: 'Fennec', clue: 'Desert fox with big ears' },
+    ]
+
+    for (const bad of ['Sea-lion', 'Fennec Fox', 'CAFÉ', 'Word3']) {
+      const result = validateListJSON({
+        topic: 'Animals',
+        name: 'Mammals',
+        items: [...base, { answer: bad, clue: 'Contains a disallowed character' }],
+      })
+
+      expect(result.success).toBe(false)
+      const answerError = result.errors?.find((err) => err.field.endsWith('answer'))
+      expect(answerError?.message).toContain(bad.toUpperCase())
+      expect(answerError?.message).toContain("aren't letters A–Z")
+    }
+  })
+
+  it('never silently strips disallowed characters (regression for #17)', () => {
+    // "CAF-É3" used to import as "CAF"; it must now be rejected, not mutated.
+    const result = validateListJSON({
+      topic: 'Food',
+      name: 'Drinks',
+      items: [
+        { answer: 'CAF-É3', clue: 'Corrupted coffee word' },
+        { answer: 'Latte', clue: 'Milky espresso drink' },
+        { answer: 'Mocha', clue: 'Chocolate espresso drink' },
+        { answer: 'Espresso', clue: 'Strong small coffee' },
+        { answer: 'Ristretto', clue: 'Even shorter espresso' },
+      ],
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.data).toBeUndefined()
   })
 
   it('rejects lists that contain duplicate answers', () => {
@@ -76,10 +116,12 @@ describe('validation helpers', () => {
       topic: 'History',
       name: 'Renaissance',
       version: 2,
-      items: Array.from({ length: 5 }, (_, index) => ({
-        answer: `artist${index + 1}`,
-        clue: `Notable renaissance artist ${index + 1}`,
-      })),
+      items: ['Raphael', 'Titian', 'Botticelli', 'Donatello', 'Caravaggio'].map(
+        (answer, index) => ({
+          answer,
+          clue: `Notable renaissance artist ${index + 1}`,
+        }),
+      ),
     })
 
     expect(parsed.success).toBe(true)
@@ -89,15 +131,19 @@ describe('validation helpers', () => {
     expect(parsed.data.version).toBe(2)
   })
 
-  it('normalizes answers by upper-casing and stripping non letters', () => {
-    expect(normalizeAnswer('Sea-horse!')).toBe('SEAHORSE')
+  it('normalizes answers by upper-casing only — disallowed characters survive to validation (#17)', () => {
+    expect(normalizeAnswer('otter')).toBe('OTTER')
+    expect(normalizeAnswer('Sea-horse!')).toBe('SEA-HORSE!')
   })
 
   it('describes formatting issues for invalid answers', () => {
     const result = validateAnswerFormat('1')
     expect(result.valid).toBe(false)
     expect(result.issues).toEqual(
-      expect.arrayContaining(['Non-letter characters removed', 'Answer too short (minimum 2 letters)']),
+      expect.arrayContaining([
+        expect.stringContaining("aren't letters A–Z"),
+        'Answer too short (minimum 2 letters)',
+      ]),
     )
   })
 

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -168,9 +168,10 @@ function parseJSONImport(content: string) {
         name: String(data.name),
         version: Number(data.version) || 1,
         items: data.items.map((item: RawImportItem) => ({
-          answer: String(item.answer)
-            .toUpperCase()
-            .replace(/[^A-Z]/g, ''),
+          // Uppercase only — disallowed characters must survive to validation so
+          // the import is denied with an error naming the word, not silently
+          // stripped (#17).
+          answer: String(item.answer).toUpperCase(),
           clue: String(item.clue),
           note: item.note ? String(item.note) : undefined,
           difficulty: item.difficulty ? Number(item.difficulty) : undefined,
@@ -213,7 +214,8 @@ function parseCSVImport(content: string) {
 
       if (values[answerIndex] && values[clueIndex]) {
         items.push({
-          answer: values[answerIndex].toUpperCase().replace(/[^A-Z]/g, ''),
+          // Uppercase only — see parseJSONImport (#17).
+          answer: values[answerIndex].toUpperCase(),
           clue: values[clueIndex],
           note: undefined,
           difficulty: undefined,

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,12 +1,34 @@
 import { z } from 'zod'
 
+// Allowed-character policy for crossword answers (#17): letters A-Z only, after
+// uppercasing. Case is the only transformation ever applied — anything else
+// (accents, digits, hyphens, spaces) is a hard validation failure, never a
+// silent strip, so an invalid word denies the import with an error naming it.
+// Shared so the CSV import (#31) applies the identical rule.
+export const ANSWER_ALLOWED_PATTERN = /^[A-Z]+$/
+
+export function findDisallowedAnswerCharacters(answer: string): string[] {
+  return Array.from(new Set(answer.toUpperCase().replace(/[A-Z]/g, '').split('')))
+}
+
+const AnswerSchema = z
+  .string()
+  .min(2, 'Answer must be at least 2 characters')
+  .max(20, 'Answer must be at most 20 characters')
+  .transform((val) => val.toUpperCase())
+  .superRefine((val, ctx) => {
+    if (!ANSWER_ALLOWED_PATTERN.test(val)) {
+      const disallowed = findDisallowedAnswerCharacters(val).join(' ')
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Answer "${val}" contains characters that aren't letters A–Z (${disallowed}). Fix this word and try again.`,
+      })
+    }
+  })
+
 // List JSON Schema validation (from PRP section 9.1)
 export const ListItemSchema = z.object({
-  answer: z
-    .string()
-    .min(2, 'Answer must be at least 2 characters')
-    .max(20, 'Answer must be at most 20 characters')
-    .transform((val) => val.toUpperCase().replace(/[^A-Z]/g, '')), // A-Z only, uppercase
+  answer: AnswerSchema,
   clue: z
     .string()
     .min(3, 'Clue must be at least 3 characters')
@@ -38,10 +60,7 @@ const DifficultyInputSchema = z.union([
 ])
 
 export const ListItemInputSchema = z.object({
-  answer: z
-    .string()
-    .min(2, 'Answer must be at least 2 characters')
-    .max(20, 'Answer must be at most 20 characters'),
+  answer: AnswerSchema,
   clue: z
     .string()
     .min(3, 'Clue must be at least 3 characters')
@@ -176,8 +195,11 @@ export function validateListJSON(data: unknown) {
   }
 }
 
+// Case is the only permitted normalization. Disallowed characters are a
+// validation failure upstream (AnswerSchema) — stripping them here would
+// silently corrupt user data (#17).
 export function normalizeAnswer(answer: string): string {
-  return answer.toUpperCase().replace(/[^A-Z]/g, '')
+  return answer.toUpperCase()
 }
 
 export function validateAnswerFormat(answer: string): {
@@ -186,24 +208,17 @@ export function validateAnswerFormat(answer: string): {
   issues: string[]
 } {
   const issues: string[] = []
-  let normalized = answer.toUpperCase()
+  const normalized = answer.toUpperCase()
 
-  // Remove non-letter characters and track what was removed
-  const originalLength = normalized.length
-  normalized = normalized.replace(/[^A-Z]/g, '')
-
-  if (normalized.length !== originalLength) {
-    issues.push('Non-letter characters removed')
+  if (!ANSWER_ALLOWED_PATTERN.test(normalized)) {
+    const disallowed = findDisallowedAnswerCharacters(normalized).join(' ')
+    issues.push(`Contains characters that aren't letters A–Z (${disallowed})`)
   }
 
   if (normalized.length < 2) {
     issues.push('Answer too short (minimum 2 letters)')
-    return { valid: false, normalized, issues }
-  }
-
-  if (normalized.length > 20) {
+  } else if (normalized.length > 20) {
     issues.push('Answer too long (maximum 20 letters)')
-    return { valid: false, normalized, issues }
   }
 
   return { valid: issues.length === 0, normalized, issues }


### PR DESCRIPTION
Closes #17

## What
- **Fail-closed answer policy** (`src/lib/validation.ts`): new shared `AnswerSchema` + `ANSWER_ALLOWED_PATTERN` + `findDisallowedAnswerCharacters`. Uppercasing is the only transformation; any remaining non-A–Z character is a Zod failure whose message names the word and the offending characters (e.g. `Answer "CAFÉ-3" contains characters that aren't letters A–Z (É - 3)`).
- All strip sites changed in lockstep (consumer sweep): `ListItemSchema`, `ListItemInputSchema` (create + update routes), `normalizeAnswer` (now uppercase-only), `validateAnswerFormat`, and both `export.ts` import parsers. No path can silently mutate an invalid answer anymore.
- Whole-import denial: one invalid word → 400 with word-naming `details`, zero writes.
- Import modal: error container now `role="alert"` (announced, CW-C-001); format hint updated (no more "auto-converted" claim).
- The rule is a single shared helper ready for CSV import (#31) to reuse.

## Tests (156 passing)
- Validation: word-naming rejection for accent/digit/hyphen/space; regression proving `CAF-É3` is rejected, not mutated to `CAF`; `normalizeAnswer` uppercase-only.
- Import route: invalid answer → 400 naming the word, `$transaction` never called; unauthenticated → 401 before validation (existing).
- New `ImportListModal` component tests: invalid answer shows word-naming alert and never calls `onSubmit`; valid list submits uppercased.

Docs: `docs/list-import-maintenance-flow.md`, `docs/specs/CROSSWISE_SPEC.md`, new `docs/uat/UAT_CW-17.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)