### PR TITLE
fix(web): render error states with retry on topics, lists, and solve pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to SemVer.
 - Puzzle generation now grows the grid (15→17→19) when a list doesn't fit, accepts partial puzzles instead of failing outright, and the solve screen discloses any words that didn't fit with a dismissible notice (#99)
 
 ### Fixed
+- Failed loads on the topics, lists, and solve screens now show a visible, dismissible error with a retry action instead of a blank or silently-empty page; the solve screen's loading state also updates reactively (#36)
 - Visiting your topics or lists while signed out now redirects to login (and back after signing in) instead of showing a false "No topics yet" screen; the topics page also gained a proper loading state (#82)
 - Puzzle generation is now independent of database row order: the same list and seed reproduce the same puzzle even after rows are updated or reordered (#77)
 - Puzzle generation no longer places the same word twice or reports success for puzzles that silently dropped most of the list; placement counts and the success threshold now reflect the real grid (#76)

--- a/src/app/solve/[id]/page.tsx
+++ b/src/app/solve/[id]/page.tsx
@@ -8,6 +8,7 @@ import SolveSurface from '@/components/SolveSurface'
 import PuzzleControls from '@/components/PuzzleControls'
 import WinModal from '@/components/WinModal'
 import { buttonClasses } from '@/components/ui/button'
+import { ErrorBanner } from '@/components/ui/error-banner'
 import type { SolveState } from '@/types/crossword'
 import { normalizeSolveState, resolveSolveState } from '../solveState'
 import type { RemoteSolveState } from '../solveState'
@@ -29,6 +30,8 @@ export default function SolvePage() {
     setWon,
     user,
     sessionHydrated,
+    isLoading,
+    error,
   } = useAppStore()
 
   const [selectedTab, setSelectedTab] = useState<'across' | 'down'>('across')
@@ -400,7 +403,9 @@ export default function SolvePage() {
     }
   }
 
-  if (useAppStore.getState().isLoading) {
+  // Subscribed value, not getState(): the loading branch must re-render
+  // reactively when the store changes (#36).
+  if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-center">
@@ -435,9 +440,15 @@ export default function SolvePage() {
       <PuzzleControls
         onNewPuzzle={handleNewPuzzle}
         onExport={handleExport}
-        isGenerating={useAppStore.getState().isLoading}
+        isGenerating={isLoading}
         autosaveStatus={autosaveStatus}
       />
+
+      {error && (
+        <div className="container mx-auto px-4 pt-4">
+          <ErrorBanner message={error} onDismiss={() => setError(null)} />
+        </div>
+      )}
 
       {currentPuzzle.unplacedWords &&
         currentPuzzle.unplacedWords.length > 0 &&

--- a/src/app/solve/__tests__/page.test.tsx
+++ b/src/app/solve/__tests__/page.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+
+import SolvePage from '../[id]/page'
+import { useAppStore } from '@/lib/store'
+
+const routerMock = { replace: vi.fn(), push: vi.fn() }
+const PUZZLE_ID = 'cpuzzle123456789012345678'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => routerMock,
+  useParams: () => ({ id: PUZZLE_ID }),
+  usePathname: () => `/solve/${PUZZLE_ID}`,
+}))
+
+vi.mock('@/lib/autosave', () => ({
+  autosaveManager: {
+    loadSolveState: vi.fn(() => null),
+    stopAutosave: vi.fn(),
+    clearSolveState: vi.fn(),
+    startAutosave: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+    forceSave: vi.fn(),
+  },
+}))
+
+const initialState = useAppStore.getState()
+
+describe('SolvePage loading state reactivity (#36)', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      ...initialState,
+      currentPuzzle: null,
+      solveState: null,
+      user: { id: 'u1', email: 'user@example.com', name: null, createdAt: '' } as never,
+      sessionHydrated: true,
+      isLoading: true,
+      error: null,
+    })
+    // Keep the page's own load effect pending so store state drives the render.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('re-renders reactively when isLoading changes in the store', async () => {
+    render(<SolvePage />)
+
+    // Loading branch while isLoading is true.
+    expect(screen.getByText('Loading puzzle…')).toBeTruthy()
+
+    // Flip the store: with the old imperative getState() read this would NOT
+    // re-render; the subscribed read must swap to the not-found branch.
+    act(() => {
+      useAppStore.setState({ isLoading: false })
+    })
+
+    expect(screen.queryByText('Loading puzzle…')).toBeNull()
+    expect(screen.getByText('Puzzle not found')).toBeTruthy()
+  })
+})

--- a/src/app/topics/[id]/lists/__tests__/page.test.tsx
+++ b/src/app/topics/[id]/lists/__tests__/page.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import ListsPage from '../page'
+import { useAppStore } from '@/lib/store'
+
+const replaceMock = vi.fn()
+const pushMock = vi.fn()
+const routerMock = { replace: replaceMock, push: pushMock }
+const TOPIC_ID = 'ctopic1234567890123456789'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => routerMock,
+  useParams: () => ({ id: TOPIC_ID }),
+  usePathname: () => `/topics/${TOPIC_ID}/lists`,
+}))
+
+vi.mock('@/lib/autosave', () => ({
+  useAutosave: () => ({ clearSolveState: vi.fn(), stopAutosave: vi.fn() }),
+}))
+
+const initialState = useAppStore.getState()
+
+describe('ListsPage error state (#36)', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      ...initialState,
+      lists: [],
+      selectedTopic: {
+        id: TOPIC_ID,
+        name: 'Biology',
+        description: null,
+        color: '#3B82F6',
+        icon: '🧬',
+      } as never,
+      user: { id: 'u1', email: 'user@example.com', name: null, createdAt: '' } as never,
+      sessionHydrated: true,
+      isLoading: false,
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('renders a visible error state when the lists fetch fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+    )
+
+    render(<ListsPage />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('Network error')
+  })
+
+  it('shows the empty state, not an error, when the topic simply has no lists', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => ({
+        ok: true,
+        status: 200,
+        json: async () =>
+          url.includes('/topics/')
+            ? { success: true, data: useAppStore.getState().selectedTopic }
+            : { success: true, data: [] },
+      })),
+    )
+
+    render(<ListsPage />)
+
+    expect(await screen.findByText('No lists yet')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/src/app/topics/[id]/lists/page.tsx
+++ b/src/app/topics/[id]/lists/page.tsx
@@ -11,6 +11,7 @@ import EditListModal from '@/components/EditListModal'
 import DeleteListModal from '@/components/DeleteListModal'
 import { Button, buttonClasses } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardTitle } from '@/components/ui/card'
+import { ErrorBanner } from '@/components/ui/error-banner'
 import { useAutosave } from '@/lib/autosave'
 
 export default function ListsPage() {
@@ -32,6 +33,7 @@ export default function ListsPage() {
     setError,
     topics,
     isLoading,
+    error,
   } = useAppStore()
 
   const [isImportModalOpen, setIsImportModalOpen] = useState(false)
@@ -43,7 +45,7 @@ export default function ListsPage() {
   const [deletingList, setDeletingList] = useState<ListWithItemsAndTopic | null>(null)
   const [isDeletingList, setIsDeletingList] = useState(false)
   const { clearSolveState, stopAutosave } = useAutosave()
-  const { isAuthenticated, isSessionPending } = useRequireSession()
+  const { isAuthenticated } = useRequireSession()
 
   const fetchTopicAndLists = useCallback(
     async (id: string) => {
@@ -383,6 +385,15 @@ export default function ListsPage() {
             <span aria-hidden="true">＋</span> Import list
           </Button>
         </div>
+
+        {error && !isLoading && (
+          <ErrorBanner
+            className="mt-8"
+            message={error}
+            onRetry={() => void fetchTopicAndLists(topicId)}
+            onDismiss={() => setError(null)}
+          />
+        )}
 
         {filteredLists.length === 0 && !isLoading ? (
           <Card className="mt-12">

--- a/src/app/topics/__tests__/page.test.tsx
+++ b/src/app/topics/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import TopicsPage from '../page'
 import { useAppStore } from '@/lib/store'
@@ -76,6 +76,54 @@ describe('TopicsPage auth gate (#82)', () => {
       expect(fetchMock).toHaveBeenCalledWith('/api/v1/topics')
     })
     expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('renders a visible error with retry when the fetch fails (#36)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => '' })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ success: true, data: [] }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TopicsPage />)
+    useAppStore.setState({
+      sessionHydrated: true,
+      user: { id: 'u1', email: 'user@example.com', name: null, createdAt: '' },
+    })
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('HTTP error')
+
+    // Retry refetches and clears the error state.
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+  })
+
+  it('shows the empty state (not the error) for an empty successful result', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ success: true, data: [] }),
+      }),
+    )
+
+    render(<TopicsPage />)
+    useAppStore.setState({
+      sessionHydrated: true,
+      user: { id: 'u1', email: 'user@example.com', name: null, createdAt: '' },
+    })
+
+    expect(await screen.findByText('No topics yet')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
   })
 
   it('redirects through login when the session expires mid-visit (401)', async () => {

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -9,10 +9,11 @@ import TopicCard from '@/components/TopicCard'
 import CreateTopicModal from '@/components/CreateTopicModal'
 import { Button, buttonClasses } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardTitle } from '@/components/ui/card'
+import { ErrorBanner } from '@/components/ui/error-banner'
 
 export default function TopicsPage() {
   const router = useRouter()
-  const { topics, setTopics, selectTopic, setLoading, setError, isLoading } = useAppStore()
+  const { topics, setTopics, selectTopic, setLoading, setError, isLoading, error } = useAppStore()
   const { isAuthenticated, isSessionPending } = useRequireSession()
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
 
@@ -132,6 +133,15 @@ export default function TopicsPage() {
             <span aria-hidden="true">＋</span> New topic
           </Button>
         </div>
+
+        {error && !isLoading && (
+          <ErrorBanner
+            className="mt-8"
+            message={error}
+            onRetry={() => void fetchTopics()}
+            onDismiss={() => setError(null)}
+          />
+        )}
 
         {isSessionPending || (isLoading && topics.length === 0) ? (
           <div className="mt-12 flex flex-col items-center gap-4 py-12" role="status">

--- a/src/components/ui/error-banner.tsx
+++ b/src/components/ui/error-banner.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils'
+
+interface ErrorBannerProps {
+  message: string
+  onRetry?: () => void
+  onDismiss?: () => void
+  className?: string
+}
+
+// Shared failure-state banner for data-driven views (#36). Announced to
+// assistive tech via role="alert"; offers retry and dismiss affordances so a
+// failed fetch is never a silent dead end.
+export function ErrorBanner({ message, onRetry, onDismiss, className }: ErrorBannerProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex items-start justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700',
+        className,
+      )}
+    >
+      <p className="min-w-0 break-words">{message}</p>
+      <div className="flex shrink-0 items-center gap-3">
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="font-medium text-red-800 underline underline-offset-2 transition-colors hover:text-red-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Try again
+          </button>
+        )}
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss error"
+            className="rounded p-1 leading-none text-red-700 transition-colors hover:bg-red-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            ✕
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #36

## What
- New shared `ErrorBanner` component (`src/components/ui/error-banner.tsx`): `role="alert"`, dismiss and optional retry affordances, keyboard-focusable controls — one presentational component instead of per-page one-offs.
- Topics page: store `error` now renders with **Try again** (refetch) and dismiss; empty state still wins for a successful empty result.
- Lists page: same banner with retry wired to `fetchTopicAndLists`.
- Solve page (set-but-not-shown audit): errors from e.g. failed regeneration now render as a dismissible banner; also replaced both imperative `useAppStore.getState().isLoading` reads with the subscribed value so the loading branch re-renders reactively.
- Error text is the store's friendly message — no stack traces or server internals.

## Tests (164 passing)
- Topics: fetch failure renders alert + retry refetches and clears it; empty success renders the empty state, not the error.
- Lists (new page test): fetch failure renders the alert; empty topic renders "No lists yet" with no alert.
- Solve (new page test): flipping `isLoading` in the store re-renders the page — fails with the old `getState()` read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)