### PR TITLE
feat(web): delete a topic and all associated data with confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to SemVer.
 ## [Unreleased]
 
 ### Added
+- Topics can now be deleted from the topics page, with a confirmation dialog that warns all lists, puzzles, and solve progress under the topic are permanently removed (#15)
 - Puzzle generation now grows the grid (15→17→19) when a list doesn't fit, accepts partial puzzles instead of failing outright, and the solve screen discloses any words that didn't fit with a dismissible notice (#99)
 
 ### Fixed

--- a/docs/components.md
+++ b/docs/components.md
@@ -60,6 +60,7 @@ if (outcome.success) {
 | --- | --- | --- |
 | `AppHeader` | `src/components/AppHeader.tsx` | Displays auth state, triggers logout flow, and navigates back to the homepage. |
 | `CreateTopicModal` / `ImportListModal` / `EditListModal` | `src/components/*Modal.tsx` | Form-heavy components handling validation feedback, dynamic item editing, and sample data loading. |
+| `ConfirmDeleteModal` | `src/components/ConfirmDeleteModal.tsx` | Shared destructive-action confirmation dialog (role=dialog, Escape cancels, focus lands on Cancel, busy state disables both actions). `DeleteTopicModal` (#15) and `DeleteListModal` (#16) are thin wrappers; `TopicCard`/`ListCard` expose the delete affordance. |
 | `CrosswordGrid` | `src/components/CrosswordGrid.tsx` | Adapts cell dimensions responsively using container-aware sizing (gap/padding/border included), maps keyboard events to store actions, highlights selected clues, and renders numbering above filled letters for clarity while keeping the grid inside its mobile card. |
 | `ClueList` | `src/components/ClueList.tsx` | Search filter, completion status indicator based on `checkResults`, and pointer/keyboard accessible selection. |
 | `PuzzleControls` | `src/components/PuzzleControls.tsx` | Exposes check/clear actions, displays progress stats, and re-routes to topics when needed. |

--- a/docs/topic-list-flow.md
+++ b/docs/topic-list-flow.md
@@ -43,6 +43,19 @@ flowchart TD
     UI --> STORE["useAppStore.setTopics/lists(...)"]
 ```
 
+## Topic Delete (#15)
+1. The delete control on a `TopicCard` opens `DeleteTopicModal` (shared
+   `ConfirmDeleteModal`), which names the topic and warns that all lists,
+   puzzles, and solve progress under it are permanently removed. Cancel/Escape
+   abort with no request.
+2. Confirm calls `DELETE /api/v1/topics/:id` (auth required; lookup scoped to
+   the owner - a non-owned id is a 404 and deletes nothing).
+3. Children are removed by `onDelete: Cascade` (lists -> items/puzzles -> solves);
+   the route deletes only the topic row and returns `{ topicId, listIds, puzzleIds }`.
+4. The client clears autosaved solve state for the returned `puzzleIds`, resets
+   the current puzzle if it belonged to a removed list, and drops the topic and
+   its lists from the store - no refresh needed, no dangling references.
+
 ## Data Artifacts
 - `topics` table
 - `lists` table
@@ -51,7 +64,8 @@ flowchart TD
 
 ## Failure Modes
 - Missing session -> 401.
-- Topic not found -> 404 / error payload.
+- Topic not found (or owned by someone else) -> 404 / error payload.
+- Delete failure -> error banner on the topics page; nothing removed locally.
 
 ## Key Files
 - `src/app/api/v1/topics/route.ts`

--- a/src/app/api/v1/topics/[id]/__tests__/route.test.ts
+++ b/src/app/api/v1/topics/[id]/__tests__/route.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 
-import { GET } from '../route'
+import { DELETE, GET } from '../route'
 import { SESSION_COOKIE_NAME } from '@/lib/auth'
 
-const { topicFindFirst } = vi.hoisted(() => ({
+const { topicFindFirst, topicDelete } = vi.hoisted(() => ({
   topicFindFirst: vi.fn(),
+  topicDelete: vi.fn(),
 }))
 
 const mockSession = vi.hoisted(() => vi.fn())
@@ -14,6 +15,7 @@ vi.mock('@/lib/db', () => ({
   prisma: {
     topic: {
       findFirst: topicFindFirst,
+      delete: topicDelete,
     },
   },
 }))
@@ -72,5 +74,82 @@ describe('/api/v1/topics/:id GET handler', () => {
     const request = new NextRequest('http://localhost/api/v1/topics/topic-1')
     const response = await GET(request, { params: Promise.resolve({ id: 'topic-1' }) })
     expect(response.status).toBe(401)
+  })
+})
+
+describe('/api/v1/topics/:id DELETE handler (#15)', () => {
+  const deleteRequest = (cookie = `${SESSION_COOKIE_NAME}=token-123`) =>
+    new NextRequest('http://localhost/api/v1/topics/topic-1', {
+      method: 'DELETE',
+      headers: cookie ? { cookie } : {},
+    })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSession.mockReset()
+    mockSession.mockResolvedValue({ user: { id: 'user-1' } })
+  })
+
+  it('deletes an owned topic and returns the affected list and puzzle ids', async () => {
+    topicFindFirst.mockResolvedValueOnce({
+      id: 'topic-1',
+      userId: 'user-1',
+      lists: [
+        { id: 'list-1', puzzles: [{ id: 'puzzle-1' }, { id: 'puzzle-2' }] },
+        { id: 'list-2', puzzles: [] },
+      ],
+    })
+    topicDelete.mockResolvedValueOnce({ id: 'topic-1' })
+
+    const response = await DELETE(deleteRequest(), {
+      params: Promise.resolve({ id: 'topic-1' }),
+    })
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.data).toEqual({
+      topicId: 'topic-1',
+      listIds: ['list-1', 'list-2'],
+      puzzleIds: ['puzzle-1', 'puzzle-2'],
+    })
+    // Cascade handles children; the route deletes only the topic row.
+    expect(topicDelete).toHaveBeenCalledWith({ where: { id: 'topic-1' } })
+  })
+
+  it("scopes the delete by owner: another user's topic returns 404 and deletes nothing", async () => {
+    topicFindFirst.mockResolvedValueOnce(null)
+
+    const response = await DELETE(deleteRequest(), {
+      params: Promise.resolve({ id: 'topic-1' }),
+    })
+
+    expect(response.status).toBe(404)
+    expect(topicFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'topic-1', userId: 'user-1' },
+      }),
+    )
+    expect(topicDelete).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 for a missing topic', async () => {
+    topicFindFirst.mockResolvedValueOnce(null)
+
+    const response = await DELETE(deleteRequest(), {
+      params: Promise.resolve({ id: 'missing' }),
+    })
+
+    expect(response.status).toBe(404)
+  })
+
+  it('rejects unauthenticated requests without deleting', async () => {
+    mockSession.mockResolvedValueOnce(null)
+
+    const response = await DELETE(deleteRequest(''), {
+      params: Promise.resolve({ id: 'topic-1' }),
+    })
+
+    expect(response.status).toBe(401)
+    expect(topicDelete).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/v1/topics/[id]/route.ts
+++ b/src/app/api/v1/topics/[id]/route.ts
@@ -113,7 +113,12 @@ export async function DELETE(
     const userId = session.user.id
     const { id } = await params
 
-    const owned = await prisma.topic.findFirst({ where: { id, userId } })
+    const owned = await prisma.topic.findFirst({
+      where: { id, userId },
+      include: {
+        lists: { select: { id: true, puzzles: { select: { id: true } } } },
+      },
+    })
     if (!owned) {
       return NextResponse.json(
         { success: false, error: { message: 'Topic not found' } },
@@ -121,11 +126,17 @@ export async function DELETE(
       )
     }
 
+    // Children are removed by onDelete: Cascade (lists -> items/puzzles -> solves).
+    // Return the affected ids so the client can clear in-memory solve/autosave
+    // state for the removed puzzles (mirrors the list-delete payload).
+    const listIds = owned.lists.map((list) => list.id)
+    const puzzleIds = owned.lists.flatMap((list) => list.puzzles.map((puzzle) => puzzle.id))
+
     await prisma.topic.delete({
       where: { id },
     })
 
-    return NextResponse.json({ success: true, data: null })
+    return NextResponse.json({ success: true, data: { topicId: id, listIds, puzzleIds } })
   } catch (error) {
     console.error('Failed to delete topic:', error)
 

--- a/src/app/topics/[id]/lists/page.tsx
+++ b/src/app/topics/[id]/lists/page.tsx
@@ -43,7 +43,7 @@ export default function ListsPage() {
   const [deletingList, setDeletingList] = useState<ListWithItemsAndTopic | null>(null)
   const [isDeletingList, setIsDeletingList] = useState(false)
   const { clearSolveState, stopAutosave } = useAutosave()
-  const { isAuthenticated, isSessionPending } = useRequireSession()
+  const { isAuthenticated } = useRequireSession()
 
   const fetchTopicAndLists = useCallback(
     async (id: string) => {

--- a/src/app/topics/__tests__/page.test.tsx
+++ b/src/app/topics/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import TopicsPage from '../page'
 import { useAppStore } from '@/lib/store'
@@ -76,6 +76,64 @@ describe('TopicsPage auth gate (#82)', () => {
       expect(fetchMock).toHaveBeenCalledWith('/api/v1/topics')
     })
     expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('topic delete flow: cancel sends no request; confirm deletes and removes the card (#15)', async () => {
+    const topic = {
+      id: 'ctopic1234567890123456789',
+      name: 'Biology',
+      description: null,
+      color: '#3B82F6',
+      icon: '🧬',
+      createdAt: new Date().toISOString(),
+    }
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            data: { topicId: topic.id, listIds: [], puzzleIds: [] },
+          }),
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ success: true, data: [topic] }),
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TopicsPage />)
+    useAppStore.setState({
+      sessionHydrated: true,
+      user: { id: 'u1', email: 'user@example.com', name: null, createdAt: '' },
+    })
+
+    // Open the confirmation from the card's delete control.
+    const deleteButton = await screen.findByRole('button', { name: 'Delete topic Biology' })
+    fireEvent.click(deleteButton)
+    expect(screen.getByRole('dialog')).toBeTruthy()
+
+    // Cancel aborts with no request and no state change.
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'DELETE')).toHaveLength(0)
+    expect(screen.getByText('Biology')).toBeTruthy()
+
+    // Reopen and confirm: DELETE fires and the card disappears.
+    fireEvent.click(screen.getByRole('button', { name: 'Delete topic Biology' }))
+    fireEvent.click(screen.getByRole('button', { name: /delete topic$/i }))
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.filter(([, init]) => init?.method === 'DELETE'),
+      ).toHaveLength(1)
+      expect(screen.queryByText('Biology')).toBeNull()
+    })
+    expect(fetchMock).toHaveBeenCalledWith(`/api/v1/topics/${topic.id}`, { method: 'DELETE' })
   })
 
   it('redirects through login when the session expires mid-visit (401)', async () => {

--- a/src/app/topics/page.tsx
+++ b/src/app/topics/page.tsx
@@ -7,14 +7,33 @@ import { useRequireSession } from '@/lib/useRequireSession'
 import { Topic } from '@/types/database'
 import TopicCard from '@/components/TopicCard'
 import CreateTopicModal from '@/components/CreateTopicModal'
+import DeleteTopicModal from '@/components/DeleteTopicModal'
 import { Button, buttonClasses } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardTitle } from '@/components/ui/card'
+import { useAutosave } from '@/lib/autosave'
 
 export default function TopicsPage() {
   const router = useRouter()
-  const { topics, setTopics, selectTopic, setLoading, setError, isLoading } = useAppStore()
+  const {
+    topics,
+    setTopics,
+    selectTopic,
+    selectedTopic,
+    selectList,
+    setLoading,
+    setError,
+    isLoading,
+    currentPuzzle,
+    setPuzzle,
+    setSolveState,
+    setWon,
+    setLists,
+  } = useAppStore()
   const { isAuthenticated, isSessionPending } = useRequireSession()
+  const { clearSolveState, stopAutosave } = useAutosave()
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
+  const [deletingTopic, setDeletingTopic] = useState<Topic | null>(null)
+  const [isDeletingTopic, setIsDeletingTopic] = useState(false)
 
   const fetchTopics = useCallback(async () => {
     setLoading(true)
@@ -115,6 +134,58 @@ export default function TopicsPage() {
     router.push(`/topics/${topic.id}/lists`)
   }
 
+  const handleCloseDeleteModal = () => {
+    if (isDeletingTopic) return
+    setDeletingTopic(null)
+  }
+
+  const handleDeleteTopic = async () => {
+    if (!deletingTopic) return
+
+    setIsDeletingTopic(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/v1/topics/${deletingTopic.id}`, { method: 'DELETE' })
+      const result = await response.json()
+
+      if (!response.ok || !result.success) {
+        setError(result.error?.message || 'Failed to delete topic')
+        return
+      }
+
+      const deletedTopicId: string = result.data?.topicId ?? deletingTopic.id
+      const deletedListIds: string[] = result.data?.listIds ?? []
+      const deletedPuzzleIds: string[] = result.data?.puzzleIds ?? []
+
+      // Wipe in-memory/autosaved state for every puzzle that just disappeared,
+      // so the UI never holds references to deleted puzzles.
+      deletedPuzzleIds.forEach((puzzleId) => clearSolveState(puzzleId))
+
+      if (currentPuzzle && deletedListIds.includes(currentPuzzle.listId)) {
+        stopAutosave()
+        setSolveState(null)
+        setPuzzle(null)
+        setWon(false)
+      }
+
+      setTopics(useAppStore.getState().topics.filter((topic) => topic.id !== deletedTopicId))
+      setLists(useAppStore.getState().lists.filter((list) => list.topicId !== deletedTopicId))
+
+      if (selectedTopic?.id === deletedTopicId) {
+        selectTopic(null)
+        selectList(null)
+      }
+
+      setDeletingTopic(null)
+    } catch (error) {
+      console.error('Failed to delete topic:', error)
+      setError('Network error while deleting the topic')
+    } finally {
+      setIsDeletingTopic(false)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background">
       <div className="container px-4 py-12">
@@ -161,7 +232,12 @@ export default function TopicsPage() {
         ) : (
           <div className="mt-10 grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
             {topics.map((topic) => (
-              <TopicCard key={topic.id} topic={topic} onClick={() => handleTopicClick(topic)} />
+              <TopicCard
+                key={topic.id}
+                topic={topic}
+                onClick={() => handleTopicClick(topic)}
+                onDelete={() => setDeletingTopic(topic)}
+              />
             ))}
           </div>
         )}
@@ -170,6 +246,14 @@ export default function TopicsPage() {
           isOpen={isCreateModalOpen}
           onClose={() => setIsCreateModalOpen(false)}
           onSubmit={handleCreateTopic}
+        />
+
+        <DeleteTopicModal
+          isOpen={deletingTopic !== null}
+          topic={deletingTopic}
+          isDeleting={isDeletingTopic}
+          onClose={handleCloseDeleteModal}
+          onConfirm={handleDeleteTopic}
         />
       </div>
     </div>

--- a/src/components/ConfirmDeleteModal.tsx
+++ b/src/components/ConfirmDeleteModal.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { useEffect, useRef, type ReactNode } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+interface ConfirmDeleteModalProps {
+  isOpen: boolean
+  title: string
+  description: ReactNode
+  confirmLabel: string
+  isDeleting?: boolean
+  onClose: () => void
+  onConfirm: () => void
+}
+
+// Shared confirmation dialog for destructive actions (#15/#16). Destructive
+// actions must never fire from a single unguarded click (CLAUDE.md); Cancel and
+// Escape abort with zero side effects, and focus lands on the safe action first.
+export default function ConfirmDeleteModal({
+  isOpen,
+  title,
+  description,
+  confirmLabel,
+  isDeleting = false,
+  onClose,
+  onConfirm,
+}: ConfirmDeleteModalProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      cancelRef.current?.focus()
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !isDeleting) {
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, isDeleting, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
+      onClick={() => {
+        if (!isDeleting) onClose()
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-delete-title"
+        className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4">
+          <h2 id="confirm-delete-title" className="text-xl font-semibold text-foreground">
+            {title}
+          </h2>
+          <div className="mt-2 text-sm text-muted-foreground">{description}</div>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <Button
+            ref={cancelRef}
+            type="button"
+            variant="outline"
+            className="w-full sm:w-auto"
+            onClick={onClose}
+            disabled={isDeleting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="w-full bg-red-600 text-white hover:bg-red-700 focus-visible:ring-2 focus-visible:ring-red-500 sm:w-auto"
+            onClick={onConfirm}
+            disabled={isDeleting}
+          >
+            {isDeleting ? 'Deleting…' : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/DeleteListModal.tsx
+++ b/src/components/DeleteListModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
+import ConfirmDeleteModal from '@/components/ConfirmDeleteModal'
 import { ListWithItemsAndTopic } from '@/types/database'
 
 interface DeleteListModalProps {
@@ -18,38 +18,22 @@ export default function DeleteListModal({
   onClose,
   onConfirm,
 }: DeleteListModalProps) {
-  if (!isOpen || !list) return null
+  if (!list) return null
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
-      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
-        <div className="mb-4">
-          <h2 className="text-xl font-semibold text-foreground">Delete &quot;{list.name}&quot;?</h2>
-          <p className="mt-2 text-sm text-muted-foreground">
-            This permanently deletes the word list and every puzzle created from it. This action
-            cannot be undone.
-          </p>
-        </div>
-        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full sm:w-auto"
-            onClick={onClose}
-            disabled={isDeleting}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            className="w-full bg-red-600 text-white hover:bg-red-700 focus-visible:ring-2 focus-visible:ring-red-500 sm:w-auto"
-            onClick={onConfirm}
-            disabled={isDeleting}
-          >
-            {isDeleting ? 'Deleting…' : 'Delete list'}
-          </Button>
-        </div>
-      </div>
-    </div>
+    <ConfirmDeleteModal
+      isOpen={isOpen}
+      title={`Delete "${list.name}"?`}
+      description={
+        <p>
+          This permanently deletes the word list and every puzzle created from it. This action
+          cannot be undone.
+        </p>
+      }
+      confirmLabel="Delete list"
+      isDeleting={isDeleting}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
   )
 }

--- a/src/components/DeleteTopicModal.tsx
+++ b/src/components/DeleteTopicModal.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import ConfirmDeleteModal from '@/components/ConfirmDeleteModal'
+import { Topic } from '@/types/database'
+
+interface DeleteTopicModalProps {
+  isOpen: boolean
+  topic: Topic | null
+  isDeleting?: boolean
+  onClose: () => void
+  onConfirm: () => void
+}
+
+export default function DeleteTopicModal({
+  isOpen,
+  topic,
+  isDeleting = false,
+  onClose,
+  onConfirm,
+}: DeleteTopicModalProps) {
+  if (!topic) return null
+
+  return (
+    <ConfirmDeleteModal
+      isOpen={isOpen}
+      title={`Delete "${topic.name}"?`}
+      description={
+        <p>
+          This permanently deletes the topic, every word list in it, and every puzzle and solve
+          progress created from those lists. This action cannot be undone.
+        </p>
+      }
+      confirmLabel="Delete topic"
+      isDeleting={isDeleting}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  )
+}

--- a/src/components/TopicCard.tsx
+++ b/src/components/TopicCard.tsx
@@ -8,9 +8,10 @@ import { Topic } from '@/types/database'
 interface TopicCardProps {
   topic: Topic & { _count?: { lists: number } }
   onClick?: () => void
+  onDelete?: () => void
 }
 
-export default function TopicCard({ topic, onClick }: TopicCardProps) {
+export default function TopicCard({ topic, onClick, onDelete }: TopicCardProps) {
   const listCount = topic._count?.lists ?? 0
   const createdAt = topic.createdAt ? format(new Date(topic.createdAt), 'MMM d, yyyy') : ''
 
@@ -48,7 +49,39 @@ export default function TopicCard({ topic, onClick }: TopicCardProps) {
             </CardDescription>
           </div>
         </div>
-        <Badge variant="outline">Topic</Badge>
+        <div className="flex items-center gap-2">
+          <Badge variant="outline">Topic</Badge>
+          {onDelete && (
+            <button
+              type="button"
+              aria-label={`Delete topic ${topic.name}`}
+              onClick={(event) => {
+                // The whole card is a navigation button — the delete control must
+                // not also trigger it.
+                event.preventDefault()
+                event.stopPropagation()
+                onDelete()
+              }}
+              onKeyDown={(event) => event.stopPropagation()}
+              className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-red-50 hover:text-red-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.8}
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 7h12M9 7V5a1 1 0 011-1h4a1 1 0 011 1v2m-7 0v12a1 1 0 001 1h6a1 1 0 001-1V7"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
       </CardHeader>
       <CardContent className="flex flex-col gap-4 px-6 pb-6 text-sm leading-relaxed text-muted-foreground">
         <p className="min-h-[3rem]">

--- a/src/components/__tests__/DeleteTopicModal.test.tsx
+++ b/src/components/__tests__/DeleteTopicModal.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import DeleteTopicModal from '../DeleteTopicModal'
+import type { Topic } from '@/types/database'
+
+const topic = { id: 't1', name: 'Biology', icon: '🧬' } as unknown as Topic
+
+describe('DeleteTopicModal (#15)', () => {
+  it('names the topic and warns about cascading data loss', () => {
+    render(
+      <DeleteTopicModal isOpen topic={topic} onClose={vi.fn()} onConfirm={vi.fn()} />,
+    )
+
+    expect(screen.getByRole('dialog').textContent).toContain('Biology')
+    expect(screen.getByRole('dialog').textContent).toMatch(/word list|puzzle|solve/i)
+  })
+
+  it('Confirm calls onConfirm; Cancel calls onClose with no confirm', () => {
+    const onConfirm = vi.fn()
+    const onClose = vi.fn()
+    render(<DeleteTopicModal isOpen topic={topic} onClose={onClose} onConfirm={onConfirm} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /delete topic/i }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('Escape cancels', () => {
+    const onClose = vi.fn()
+    render(<DeleteTopicModal isOpen topic={topic} onClose={onClose} onConfirm={vi.fn()} />)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('busy state disables both buttons and blocks Escape', () => {
+    const onClose = vi.fn()
+    render(
+      <DeleteTopicModal isOpen isDeleting topic={topic} onClose={onClose} onConfirm={vi.fn()} />,
+    )
+
+    expect(screen.getByRole('button', { name: /deleting/i })).toHaveProperty('disabled', true)
+    expect(screen.getByRole('button', { name: /cancel/i })).toHaveProperty('disabled', true)
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('focuses the safe (Cancel) action when opened', () => {
+    render(<DeleteTopicModal isOpen topic={topic} onClose={vi.fn()} onConfirm={vi.fn()} />)
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: /cancel/i }))
+  })
+})


### PR DESCRIPTION
Closes #15

## What
- **API**: `DELETE /api/v1/topics/:id` (already auth + owner-scoped since #34) now returns `{ topicId, listIds, puzzleIds }` so the client can reconcile state — mirroring the list-delete payload. Children removed via `onDelete: Cascade`; the route deletes only the topic row.
- **Shared `ConfirmDeleteModal`** (new): role=dialog + aria-modal + labelled title, Escape cancels (blocked while deleting), backdrop click cancels, initial focus on the safe Cancel action, busy state disables both buttons. `DeleteTopicModal` (new) and the existing `DeleteListModal` are now thin wrappers — the list modal gained the same a11y behaviour for free (coordinates with #16/#37).
- **`TopicCard`**: delete (trash) control with an accessible name; stops propagation so it never triggers the card's navigation.
- **Topics page**: confirm → DELETE → clears autosaved solve state for every returned puzzle id, resets the current puzzle if it belonged to a deleted list, drops the topic and its lists from the store, clears selection. Errors surface via the #36 error banner. Cancel aborts with zero side effects.

Ownership note from the issue is stale: `Topic.userId` shipped in #34, and this route already scopes by owner — no new ADR needed.

## Tests (180 passing)
- Route: owned delete returns the id payload and calls `topic.delete` only for the topic row; non-owned → 404 with owner-scoped lookup and **no delete**; missing → 404; unauthenticated → 401 with no delete.
- `DeleteTopicModal`: names the topic, warns about cascading loss, confirm/cancel wiring, Escape cancels, busy state disables + blocks Escape, focus lands on Cancel.
- Topics page flow: cancel sends no request; confirm fires exactly one DELETE and removes the card without refresh.

Docs: `docs/topic-list-flow.md` (delete flow), `docs/components.md`, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)