### PR TITLE
chore(web): harden list delete with modal a11y tests, cascade contract guard, and flow docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to SemVer.
 - Puzzle generation now grows the grid (15→17→19) when a list doesn't fit, accepts partial puzzles instead of failing outright, and the solve screen discloses any words that didn't fit with a dismissible notice (#99)
 
 ### Fixed
+- Delete-list confirmation is now fully keyboard-accessible: Escape cancels, focus lands on the safe Cancel action, and the dialog is announced to assistive tech (#16)
 - Failed loads on the topics, lists, and solve screens now show a visible, dismissible error with a retry action instead of a blank or silently-empty page; the solve screen's loading state also updates reactively (#36)
 - Importing a list with an answer containing characters outside A–Z (accents, digits, hyphens, spaces) now fails with an error naming the word, instead of silently stripping characters and corrupting the list (#17)
 - Visiting your topics or lists while signed out now redirects to login (and back after signing in) instead of showing a false "No topics yet" screen; the topics page also gained a proper loading state (#82)

--- a/docs/list-import-maintenance-flow.md
+++ b/docs/list-import-maintenance-flow.md
@@ -52,6 +52,18 @@ flowchart TD
     RESP --> UI
 ```
 
+## List Delete (#16)
+1. The delete control on a `ListCard` opens `DeleteListModal` (shared
+   `ConfirmDeleteModal`): names the list, warns puzzles and solve progress are
+   permanently removed. Cancel/Escape abort with no request.
+2. Confirm calls `DELETE /api/v1/lists/:id` (auth required; lookup scoped to the
+   owner via the list's topic - a non-owned id is a 404 and deletes nothing).
+3. Items, puzzles, and solves are removed by `onDelete: Cascade` (guarded by
+   `tests/schema-cascade.test.ts`); the route returns `{ listId, puzzleIds }`.
+4. The client clears autosaved solve state for the returned `puzzleIds`, resets
+   the current puzzle if it belonged to the deleted list, and drops the list
+   from the store - no dangling puzzles or solve-history references remain.
+
 ## Data Artifacts
 - `lists` table
 - `list_items` table

--- a/src/components/__tests__/DeleteListModal.test.tsx
+++ b/src/components/__tests__/DeleteListModal.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import DeleteListModal from '../DeleteListModal'
+import type { ListWithItemsAndTopic } from '@/types/database'
+
+const list = { id: 'l1', name: 'Wildlife', version: 1 } as unknown as ListWithItemsAndTopic
+
+describe('DeleteListModal (#16)', () => {
+  it('names the list and warns puzzles are permanently removed', () => {
+    render(<DeleteListModal isOpen list={list} onClose={vi.fn()} onConfirm={vi.fn()} />)
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.textContent).toContain('Wildlife')
+    expect(dialog.textContent).toMatch(/permanently deletes .* every puzzle/i)
+  })
+
+  it('Confirm calls onConfirm; Cancel calls onClose', () => {
+    const onConfirm = vi.fn()
+    const onClose = vi.fn()
+    render(<DeleteListModal isOpen list={list} onClose={onClose} onConfirm={onConfirm} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /delete list/i }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('Escape cancels and busy state disables both buttons', () => {
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <DeleteListModal isOpen list={list} onClose={onClose} onConfirm={vi.fn()} />,
+    )
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <DeleteListModal isOpen isDeleting list={list} onClose={onClose} onConfirm={vi.fn()} />,
+    )
+    expect(screen.getByRole('button', { name: /deleting/i })).toHaveProperty('disabled', true)
+    expect(screen.getByRole('button', { name: /cancel/i })).toHaveProperty('disabled', true)
+  })
+
+  it('renders nothing when closed', () => {
+    render(<DeleteListModal isOpen={false} list={list} onClose={vi.fn()} onConfirm={vi.fn()} />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})

--- a/tests/schema-cascade.test.ts
+++ b/tests/schema-cascade.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Deleting a topic or list relies entirely on Prisma referential actions to
+// remove children (#15/#16): the routes delete a single row and trust the
+// cascade to leave no orphans. This contract lives in the schema, so guard it
+// here — losing one of these `onDelete: Cascade` declarations would silently
+// start orphaning rows (or failing deletes) in production.
+describe('prisma schema cascade contract (#15/#16)', () => {
+  const schema = readFileSync(join(process.cwd(), 'prisma', 'schema.prisma'), 'utf8')
+
+  const modelBlock = (name: string) => {
+    const match = schema.match(new RegExp(`model ${name} \\{[\\s\\S]*?\\n\\}`, 'm'))
+    expect(match, `model ${name} missing from schema`).toBeTruthy()
+    return match![0]
+  }
+
+  const relationCascades = (model: string, relationTarget: string) => {
+    const block = modelBlock(model)
+    const line = block
+      .split('\n')
+      .find((l) => l.includes(`${relationTarget} `) && l.includes('@relation'))
+    expect(line, `${model} -> ${relationTarget} relation missing`).toBeTruthy()
+    expect(line, `${model} -> ${relationTarget} must declare onDelete: Cascade`).toContain(
+      'onDelete: Cascade',
+    )
+  }
+
+  it('List cascades from Topic', () => relationCascades('List', 'Topic'))
+  it('ListItem cascades from List', () => relationCascades('ListItem', 'List'))
+  it('Puzzle cascades from List', () => relationCascades('Puzzle', 'List'))
+  it('Solve cascades from Puzzle', () => relationCascades('Solve', 'Puzzle'))
+})


### PR DESCRIPTION
Closes #16

This was a verify-and-complete pass — the DELETE route was already correct (session gate, owner-scoped lookup via the list's topic, 404 for non-owned/missing, `{ listId, puzzleIds }` payload, cascade-based cleanup), and the lists-page flow already clears solve state for returned puzzle ids, resets the current puzzle, and removes the card. What was missing:

## Added
- **`DeleteListModal` component tests** (previously untested): names the list, warns about puzzle/solve removal, confirm/cancel wiring, Escape cancels, busy state disables both buttons, closed renders nothing. The modal itself gained Escape/focus/dialog semantics via the shared `ConfirmDeleteModal` in #117.
- **Cascade contract guard** (`tests/schema-cascade.test.ts`): the delete routes remove a single row and trust `onDelete: Cascade` for children — this test fails if any of Topic→List, List→ItemList/Puzzle, Puzzle→Solve loses its cascade declaration, which would silently orphan rows.
- **Docs**: `docs/list-import-maintenance-flow.md` now documents the delete flow (confirmation, ownership scoping, cascade, client state cleanup).

Isolation and auth-boundary route tests already existed (`route.test.ts`: owner-scoped 404, 401, failure handling) — verified, not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)