### PR TITLE
fix(web): export a printable blank puzzle instead of raw JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to SemVer.
 - Puzzle generation now grows the grid (15→17→19) when a list doesn't fit, accepts partial puzzles instead of failing outright, and the solve screen discloses any words that didn't fit with a dismissible notice (#99)
 
 ### Fixed
+- The Export action on a list now produces a blank printable crossword (empty numbered grid plus across/down clues, no answers) built from the list's most recent puzzle, instead of downloading raw list JSON; lists without a generated puzzle get a friendly prompt to generate one first (#2)
 - Delete-list confirmation is now fully keyboard-accessible: Escape cancels, focus lands on the safe Cancel action, and the dialog is announced to assistive tech (#16)
 - Failed loads on the topics, lists, and solve screens now show a visible, dismissible error with a retry action instead of a blank or silently-empty page; the solve screen's loading state also updates reactively (#36)
 - Importing a list with an answer containing characters outside A–Z (accents, digits, hyphens, spaces) now fails with an error naming the word, instead of silently stripping characters and corrupting the list (#17)

--- a/docs/import-export-flow.md
+++ b/docs/import-export-flow.md
@@ -4,7 +4,8 @@
 Summarize how lists and solve states are exported and imported.
 
 ## Entry Points
-- `GET /api/v1/lists/:id/export`
+- Lists UI "Export" button → printable blank crossword (client-side, via `GET /api/v1/lists/:id/puzzles`)
+- `GET /api/v1/lists/:id/export` (raw list JSON — data interchange, not wired to the Export button)
 - `autosaveManager.exportSolveState(puzzleId)`
 - `autosaveManager.importSolveState(puzzleId, json)`
 
@@ -14,14 +15,35 @@ Summarize how lists and solve states are exported and imported.
 - Export API route
 - Browser storage
 
-## Step-by-Step (List Export)
+## Step-by-Step (Printable Puzzle Export — the "Export" button, #2)
+1. User clicks "Export" on a list card.
+2. Client fetches `GET /api/v1/lists/:id/puzzles` (auth + ownership scoped, newest first) and takes the **most recent** puzzle.
+3. If the list has no generated puzzle, a friendly error banner is shown ("Generate a puzzle first — this list doesn't have one yet.") and nothing downloads.
+4. `buildPrintableCrosswordHTML` (in `src/lib/export.ts`) renders a self-contained HTML document: heading with the list name, an empty numbered grid (block cells solid, letter cells blank with start-of-word numbers), and Across/Down clue lists. **No answer letters appear anywhere** — the builder follows the structure-only discipline of `exportPuzzleState`. All user text (list name, clues) is HTML-escaped.
+5. `openPrintableCrossword` opens the document in a new tab and triggers the print dialog. If the popup is blocked, it falls back to downloading the HTML file.
+
+```mermaid
+flowchart TD
+    UI[Lists UI: Export] --> API[GET /api/v1/lists/:id/puzzles]
+    API --> LATEST{Has puzzles?}
+    LATEST -- No --> ERR[Error banner: generate a puzzle first]
+    LATEST -- Yes --> BUILD[buildPrintableCrosswordHTML — blank grid + clues, no answers]
+    BUILD --> PRINT[New tab + print dialog]
+    PRINT -- popup blocked --> DL[Download .html fallback]
+```
+
+## Step-by-Step (Raw List Export — data interchange)
+`exportListAsJSON` / `exportListAsCSV` and the `GET /api/v1/lists/:id/export` route remain
+for exchanging word lists in the import schema format (e.g. re-importing on another
+account). They are no longer triggered by the list card's Export button.
+
 1. Client requests `GET /api/v1/lists/:id/export`.
 2. API returns PRP-compliant JSON with `Content-Disposition`.
 3. Client downloads the Blob.
 
 ```mermaid
 flowchart TD
-    UI[Lists UI] --> API[GET /api/v1/lists/:id/export]
+    UI[Client] --> API[GET /api/v1/lists/:id/export]
     API --> RESP[JSON + Content-Disposition]
     RESP --> DL[Download Blob]
 ```
@@ -54,11 +76,15 @@ flowchart TD
 ```
 
 ## Data Artifacts
+- Printable blank crossword (self-contained HTML — grid structure + clues, no answers, no PII)
 - List export JSON (PRP)
 - Solve export JSON (local format)
 - `crosswise_solve_{puzzleId}` entry in `localStorage`
 
 ## Key Files
+- `src/lib/export.ts` (`buildPrintableCrosswordHTML`, `openPrintableCrossword`)
+- `src/app/topics/[id]/lists/page.tsx` (`handleExportList`)
+- `src/app/api/v1/lists/[id]/puzzles/route.ts`
 - `src/app/api/v1/lists/[id]/export/route.ts`
 - `src/lib/autosave.ts`
 - `src/components/PuzzleControls.tsx`

--- a/docs/specs/CROSSWISE_SPEC.md
+++ b/docs/specs/CROSSWISE_SPEC.md
@@ -32,7 +32,8 @@ This document is the authoritative product + engineering specification for the c
    - Import via JSON (and CSV parsing exists client-side in `export.ts`).
    - Update list items, add/remove items, update name/version.
    - Delete lists, which also removes associated puzzles/solves.
-   - Export list as JSON per import schema.
+   - The lists page "Export" action produces a **blank printable crossword** built client-side from the list's most recent puzzle: an empty numbered grid plus across/down clue lists, with no answer letters anywhere (#2). A list with no generated puzzle gets a friendly error prompting to generate one first.
+   - Raw list export as JSON per import schema remains available via `GET /api/v1/lists/:id/export` (data interchange only).
 
 3. **Puzzle generation**
    - Generate from a list using up to 150 items; selection and placement are seeded and reproducible (ADR-006).
@@ -219,7 +220,9 @@ Authentication: cookie `crosswise_session` required for most endpoints.
 
 - `GET /api/v1/lists/:id/export`
   - Auth required.
-  - Returns JSON file download in import schema format.
+  - Returns JSON file download in import schema format (data interchange only — the
+    lists page "Export" button instead builds a printable blank crossword client-side
+    from `GET /api/v1/lists/:id/puzzles`, #2).
   - Errors: 404, 500.
 
 - `DELETE /api/v1/lists/:id`
@@ -230,7 +233,8 @@ Authentication: cookie `crosswise_session` required for most endpoints.
 
 - `GET /api/v1/lists/:id/puzzles`
   - Auth required.
-  - Returns 10 most recent puzzles for list.
+  - Returns 10 most recent puzzles for list (newest first). The printable blank
+    export uses the first entry as the "most recent puzzle" (#2).
 
 ### Puzzles
 - `POST /api/v1/puzzles/generate`

--- a/docs/uat/UAT_CW-2.md
+++ b/docs/uat/UAT_CW-2.md
@@ -1,0 +1,41 @@
+# UAT — CW-2: Export a printable blank puzzle instead of raw JSON
+
+- Work Item: CW-2 (#2)
+- Feature / Workflow: Lists page "Export" action → blank printable crossword
+- Environment: local / preview
+
+## Behavior Under Test
+
+Clicking "Export" on a list card must produce a **blank printable crossword** —
+an empty numbered grid plus across/down clue lists, built from the list's most
+recent generated puzzle — instead of downloading the raw list JSON. The output
+must contain **no answer letters and no PII** (audience includes minors,
+Decision 1). A list with no generated puzzle must show a friendly error, not
+download anything.
+
+## Acceptance Scenarios
+
+| # | Scenario | Steps | Expected |
+|---|---|---|---|
+| 1 | Happy path | Generate a puzzle for a list, click "Export" | New tab opens with a print dialog: heading = list name, empty numbered grid (black blocks, blank white squares with small start-of-word numbers), "Across" and "Down" clue lists |
+| 2 | No answers leak | Inspect the exported page source | No answer letters appear anywhere (grid cells are empty; clues only); no email/account/session data on the sheet |
+| 3 | No raw JSON | Click "Export" | No `.json` file downloads; the raw list JSON endpoint is not used by the button |
+| 4 | No puzzle yet | Click "Export" on a list that has never generated a puzzle | Error banner: "Generate a puzzle first — this list doesn't have one yet."; nothing downloads or opens |
+| 5 | Most recent puzzle | Generate two puzzles with different seeds, click "Export" | The printed grid/clues match the newest puzzle (compare numbering with the solve screen) |
+| 6 | Popup blocked | Block popups for the site, click "Export" | A self-contained `.html` file downloads instead; opening it shows the same printable page |
+| 7 | Hostile clue text | Import a list with a clue containing `<script>alert(1)</script>`, generate, export | The clue renders as literal text on the sheet; no script executes |
+| 8 | Print fidelity | Print (or print-preview) grids at sizes 9x9 and 19x19 | Grid fits the page without clipping; block cells print solid dark |
+| 9 | Accessibility | Reach the "Export" button by keyboard (Tab) and activate with Enter | Button is focusable with a visible focus ring and operable by keyboard (WCAG 2.2 AA, CW-C-001) |
+| 10 | Auth boundary | Call `GET /api/v1/lists/:id/puzzles` without a session, or for another user's list | 401 without a session; another user's list yields no puzzles (ownership-scoped query) |
+
+## Notes
+
+- The printable document is built client-side by `buildPrintableCrosswordHTML`
+  in `src/lib/export.ts`, which mirrors the structure-only discipline of
+  `exportPuzzleState` (never writes `cell.letter` or `clue.answer`).
+- Puzzle data comes from `GET /api/v1/lists/:id/puzzles` (newest first); the
+  export targets the first entry.
+- Raw JSON/CSV list export (`exportListAsJSON` / `exportListAsCSV`,
+  `GET /api/v1/lists/:id/export`) remains for data interchange and is out of
+  scope here; an answer-key (filled grid) export is tracked separately if
+  requested.

--- a/src/app/api/v1/lists/[id]/__tests__/puzzles.test.ts
+++ b/src/app/api/v1/lists/[id]/__tests__/puzzles.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import { GET } from '../puzzles/route'
+import { SESSION_COOKIE_NAME } from '@/lib/auth'
+
+const { puzzleFindMany } = vi.hoisted(() => ({
+  puzzleFindMany: vi.fn(),
+}))
+
+const mockSession = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    puzzle: {
+      findMany: puzzleFindMany,
+    },
+  },
+}))
+
+vi.mock('@/lib/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth')>('@/lib/auth')
+  return {
+    ...actual,
+    getSessionForToken: mockSession,
+  }
+})
+
+describe('/api/v1/lists/:id/puzzles auth enforcement (printable export data path, #2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSession.mockReset()
+    mockSession.mockResolvedValue({ user: { id: 'user-1' } })
+  })
+
+  it('returns 401 for unauthenticated requests', async () => {
+    mockSession.mockResolvedValueOnce(null)
+    const request = new NextRequest('http://localhost/api/v1/lists/clist123/puzzles')
+
+    const response = await GET(request, { params: Promise.resolve({ id: 'clist123' }) })
+
+    expect(response.status).toBe(401)
+    expect(puzzleFindMany).not.toHaveBeenCalled()
+  })
+
+  it('scopes the lookup by owner so another user’s list yields no puzzles', async () => {
+    puzzleFindMany.mockResolvedValueOnce([])
+
+    const request = new NextRequest('http://localhost/api/v1/lists/other-users-list/puzzles', {
+      headers: { cookie: `${SESSION_COOKIE_NAME}=token-123` },
+    })
+    const response = await GET(request, {
+      params: Promise.resolve({ id: 'other-users-list' }),
+    })
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.data).toEqual([])
+    expect(puzzleFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { listId: 'other-users-list', list: { topic: { userId: 'user-1' } } },
+      }),
+    )
+  })
+
+  it('returns puzzles newest-first so the client can pick the most recent', async () => {
+    const puzzles = [
+      { id: 'p-new', createdAt: '2026-07-02T00:00:00Z' },
+      { id: 'p-old', createdAt: '2026-07-01T00:00:00Z' },
+    ]
+    puzzleFindMany.mockResolvedValueOnce(puzzles)
+
+    const request = new NextRequest('http://localhost/api/v1/lists/clist123/puzzles', {
+      headers: { cookie: `${SESSION_COOKIE_NAME}=token-123` },
+    })
+    const response = await GET(request, { params: Promise.resolve({ id: 'clist123' }) })
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.data[0].id).toBe('p-new')
+    expect(puzzleFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: 'desc' } }),
+    )
+  })
+})

--- a/src/app/topics/[id]/lists/__tests__/page.test.tsx
+++ b/src/app/topics/[id]/lists/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import ListsPage from '../page'
 import { useAppStore } from '@/lib/store'
@@ -21,6 +21,27 @@ vi.mock('@/lib/autosave', () => ({
 }))
 
 const initialState = useAppStore.getState()
+
+const sampleListFor = (topicId: string) => ({
+  id: 'clist1234567890123456789',
+  name: 'Marine mammals',
+  version: 1,
+  topicId,
+  source: 'USER',
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-02T00:00:00Z',
+  items: [
+    { id: 'item-1', answer: 'OTTER', clue: 'Playful swimmer', note: null, difficulty: 'EASY' },
+  ],
+  topic: {
+    id: topicId,
+    name: 'Biology',
+    description: null,
+    color: '#3B82F6',
+    icon: '🧬',
+  },
+  userSolves: [],
+})
 
 describe('ListsPage error state (#36)', () => {
   beforeEach(() => {
@@ -56,6 +77,97 @@ describe('ListsPage error state (#36)', () => {
 
     const alert = await screen.findByRole('alert')
     expect(alert.textContent).toContain('Network error')
+  })
+
+  it('shows a friendly message when exporting a list that has no puzzle yet (#2)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          if (url.includes('/puzzles')) return { success: true, data: [] }
+          if (url.includes('/topics/')) {
+            return { success: true, data: useAppStore.getState().selectedTopic }
+          }
+          return { success: true, data: [sampleListFor(TOPIC_ID)] }
+        },
+      })),
+    )
+
+    render(<ListsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Export' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain("Generate a puzzle first")
+  })
+
+  it('opens a printable blank crossword when exporting a list with a puzzle (#2)', async () => {
+    const grid = {
+      size: { rows: 1, cols: 2 },
+      cells: [
+        [
+          { row: 0, col: 0, type: 'cell', letter: 'Q', number: 1 },
+          { row: 0, col: 1, type: 'cell', letter: 'X' },
+        ],
+      ],
+    }
+    const numbering = {
+      across: [
+        { number: 1, clue: 'Printable hint', row: 0, col: 0, length: 2, answer: 'QX', direction: 'across' },
+      ],
+      down: [],
+    }
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(async (url: string) => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          if (url.includes('/puzzles')) {
+            return {
+              success: true,
+              data: [
+                {
+                  id: 'puzzle-1',
+                  grid: JSON.stringify(grid),
+                  numbering: JSON.stringify(numbering),
+                  createdAt: '2026-07-01T00:00:00Z',
+                },
+              ],
+            }
+          }
+          if (url.includes('/topics/')) {
+            return { success: true, data: useAppStore.getState().selectedTopic }
+          }
+          return { success: true, data: [sampleListFor(TOPIC_ID)] }
+        },
+      })),
+    )
+
+    const fakeWindow = {
+      document: { open: vi.fn(), write: vi.fn(), close: vi.fn() },
+      focus: vi.fn(),
+      print: vi.fn(),
+    }
+    vi.stubGlobal('open', vi.fn(() => fakeWindow))
+
+    render(<ListsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Export' }))
+
+    const writtenHtml = await vi.waitFor(() => {
+      expect(fakeWindow.document.write).toHaveBeenCalled()
+      return fakeWindow.document.write.mock.calls[0][0] as string
+    })
+
+    // Blank printable crossword: clue text present, answer letters absent.
+    expect(writtenHtml).toContain('Printable hint')
+    expect(writtenHtml).not.toMatch(/[QX]/)
+    expect(fakeWindow.print).toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).toBeNull()
   })
 
   it('shows the empty state, not an error, when the topic simply has no lists', async () => {

--- a/src/app/topics/[id]/lists/page.tsx
+++ b/src/app/topics/[id]/lists/page.tsx
@@ -13,6 +13,15 @@ import { Button, buttonClasses } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardTitle } from '@/components/ui/card'
 import { ErrorBanner } from '@/components/ui/error-banner'
 import { useAutosave } from '@/lib/autosave'
+import {
+  buildPrintableCrosswordHTML,
+  generateFilename,
+  openPrintableCrossword,
+} from '@/lib/export'
+import type {
+  CrosswordGrid as CrosswordGridType,
+  CrosswordNumbering,
+} from '@/types/crossword'
 
 export default function ListsPage() {
   const router = useRouter()
@@ -321,26 +330,37 @@ export default function ListsPage() {
     }
   }
 
+  // Export = blank printable crossword (empty numbered grid + clues, no
+  // answers) built from the list's most recent puzzle (#2). Raw JSON/CSV
+  // helpers in src/lib/export.ts remain available for data interchange.
   const handleExportList = async (list: ListWithItemsAndTopic) => {
-    try {
-      const response = await fetch(`/api/v1/lists/${list.id}/export`)
+    setError(null)
 
-      if (response.ok) {
-        const blob = await response.blob()
-        const url = URL.createObjectURL(blob)
-        const link = document.createElement('a')
-        link.href = url
-        link.download = `${list.name.replace(/[^a-zA-Z0-9]/g, '_')}_v${list.version}.json`
-        document.body.appendChild(link)
-        link.click()
-        document.body.removeChild(link)
-        URL.revokeObjectURL(url)
-      } else {
-        setError('Failed to export list')
+    try {
+      const response = await fetch(`/api/v1/lists/${list.id}/puzzles`)
+      const result = await response.json()
+
+      if (!response.ok || !result.success) {
+        setError(result.error?.message || 'Failed to export puzzle')
+        return
       }
+
+      // The endpoint returns puzzles newest-first; export targets the most recent.
+      const latestPuzzle = (result.data as Array<{ grid: string; numbering: string }>)[0]
+
+      if (!latestPuzzle) {
+        setError("Generate a puzzle first — this list doesn't have one yet.")
+        return
+      }
+
+      const grid = JSON.parse(latestPuzzle.grid) as CrosswordGridType
+      const numbering = JSON.parse(latestPuzzle.numbering) as CrosswordNumbering
+
+      const html = buildPrintableCrosswordHTML(list.name, grid, numbering)
+      openPrintableCrossword(html, generateFilename(list.name, 'html'))
     } catch (error) {
       setError('Network error')
-      console.error('Failed to export list:', error)
+      console.error('Failed to export printable puzzle:', error)
     }
   }
 

--- a/src/lib/__tests__/export.test.ts
+++ b/src/lib/__tests__/export.test.ts
@@ -7,6 +7,8 @@ import {
   generateFilename,
   parseImportFile,
   downloadFile,
+  buildPrintableCrosswordHTML,
+  openPrintableCrossword,
 } from '../export'
 import type { ListWithItemsAndTopic } from '@/types/database'
 import type { CrosswordGrid, CrosswordNumbering, SolveState } from '@/types/crossword'
@@ -175,6 +177,166 @@ describe('export helpers', () => {
 
   it('throws for unsupported import formats', () => {
     expect(() => parseImportFile('content', 'data.txt')).toThrow(/Unsupported file format/)
+  })
+})
+
+describe('buildPrintableCrosswordHTML', () => {
+  // Contrived answers built from letters (Q, X, Z, J, V) that never appear in
+  // the clue texts or list name, so the "no answer letters" assertion is airtight.
+  const printableGrid: CrosswordGrid = {
+    size: { rows: 3, cols: 3 },
+    cells: [
+      [
+        { row: 0, col: 0, type: 'cell', letter: 'Q', number: 1 },
+        { row: 0, col: 1, type: 'cell', letter: 'X', number: 2 },
+        { row: 0, col: 2, type: 'block' },
+      ],
+      [
+        { row: 1, col: 0, type: 'cell', letter: 'Z' },
+        { row: 1, col: 1, type: 'block' },
+        { row: 1, col: 2, type: 'block' },
+      ],
+      [
+        { row: 2, col: 0, type: 'cell', letter: 'J' },
+        { row: 2, col: 1, type: 'block' },
+        { row: 2, col: 2, type: 'block' },
+      ],
+    ],
+  }
+
+  const printableNumbering: CrosswordNumbering = {
+    across: [
+      { number: 1, clue: 'First hint here', row: 0, col: 0, length: 2, answer: 'QX', direction: 'across' },
+    ],
+    down: [
+      { number: 1, clue: 'Second hint here', row: 0, col: 0, length: 3, answer: 'QZJ', direction: 'down' },
+    ],
+  }
+
+  it('renders the heading, numbered cells, and across/down clue lists', () => {
+    const html = buildPrintableCrosswordHTML('Marine mammals', printableGrid, printableNumbering)
+
+    expect(html).toContain('Marine mammals')
+    expect(html).toContain('Across')
+    expect(html).toContain('Down')
+    expect(html).toContain('<li value="1">First hint here</li>')
+    expect(html).toContain('<li value="1">Second hint here</li>')
+    // Start-of-word number rendered in the starting cell
+    expect(html).toContain('<span class="num">1</span>')
+  })
+
+  it('contains none of the answer letters', () => {
+    const html = buildPrintableCrosswordHTML('Marine mammals', printableGrid, printableNumbering)
+
+    // Answers are built exclusively from Q/X/Z/J/V; none may leak into the output.
+    expect(html).not.toMatch(/[QXZJV]/)
+  })
+
+  it('renders block cells and letter cells differently', () => {
+    const html = buildPrintableCrosswordHTML('Marine mammals', printableGrid, printableNumbering)
+
+    const blockCount = (html.match(/<td class="block">/g) ?? []).length
+    const cellCount = (html.match(/<td class="cell">/g) ?? []).length
+
+    expect(blockCount).toBe(5)
+    expect(cellCount).toBe(4)
+    // Block cells never carry a number
+    expect(html).not.toContain('<td class="block"><span')
+  })
+
+  it('does not crash on a single-word grid with no down clues', () => {
+    const singleWordGrid: CrosswordGrid = {
+      size: { rows: 1, cols: 2 },
+      cells: [
+        [
+          { row: 0, col: 0, type: 'cell', letter: 'Q', number: 1 },
+          { row: 0, col: 1, type: 'cell', letter: 'X' },
+        ],
+      ],
+    }
+    const singleNumbering: CrosswordNumbering = {
+      across: [
+        { number: 1, clue: 'Only word', row: 0, col: 0, length: 2, answer: 'QX', direction: 'across' },
+      ],
+      down: [],
+    }
+
+    const html = buildPrintableCrosswordHTML('Tiny list', singleWordGrid, singleNumbering)
+
+    expect(html).toContain('Only word')
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).not.toMatch(/[QXZJV]/)
+  })
+
+  it('escapes user-provided markup in the list name and clues', () => {
+    const hostileNumbering: CrosswordNumbering = {
+      across: [
+        {
+          number: 1,
+          clue: '<script>alert("pwn")</script>',
+          row: 0,
+          col: 0,
+          length: 2,
+          answer: 'QX',
+          direction: 'across',
+        },
+      ],
+      down: [],
+    }
+
+    const html = buildPrintableCrosswordHTML(
+      '<img src=y onerror=alert(1)>',
+      printableGrid,
+      hostileNumbering,
+    )
+
+    expect(html).not.toContain('<script>alert')
+    expect(html).not.toContain('<img src=y')
+    expect(html).toContain('&lt;script&gt;')
+    expect(html).toContain('&lt;img src=y onerror=alert(1)&gt;')
+  })
+})
+
+describe('openPrintableCrossword', () => {
+  const originalCreateObjectUrl = URL.createObjectURL
+  const originalRevokeObjectUrl = URL.revokeObjectURL
+
+  beforeEach(() => {
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectUrl
+    URL.revokeObjectURL = originalRevokeObjectUrl
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('writes the document into a new window and triggers print', () => {
+    const fakeWindow = {
+      document: { open: vi.fn(), write: vi.fn(), close: vi.fn() },
+      focus: vi.fn(),
+      print: vi.fn(),
+    }
+    const openSpy = vi.fn(() => fakeWindow)
+    vi.stubGlobal('open', openSpy)
+
+    openPrintableCrossword('<html>doc</html>', 'puzzle.html')
+
+    expect(openSpy).toHaveBeenCalledWith('', '_blank')
+    expect(fakeWindow.document.write).toHaveBeenCalledWith('<html>doc</html>')
+    expect(fakeWindow.print).toHaveBeenCalled()
+  })
+
+  it('falls back to downloading the HTML file when the popup is blocked', () => {
+    vi.stubGlobal('open', vi.fn(() => null))
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+
+    openPrintableCrossword('<html>doc</html>', 'puzzle.html')
+
+    expect(URL.createObjectURL).toHaveBeenCalled()
+    expect(clickSpy).toHaveBeenCalled()
   })
 })
 

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -98,6 +98,155 @@ export function exportPuzzleState(
   return JSON.stringify(exportData, null, 2)
 }
 
+// Escape user-provided text (list names, clues) so markup or scripts inside it
+// render as inert text in the printable document.
+function escapeHTML(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * Build a fully self-contained printable HTML document for a blank crossword:
+ * an empty numbered grid plus across/down clue lists. Mirrors the
+ * structure-only discipline of `exportPuzzleState` — no answer letters are
+ * ever written to the output (#2).
+ */
+export function buildPrintableCrosswordHTML(
+  listName: string,
+  grid: CrosswordGrid,
+  numbering: CrosswordNumbering,
+): string {
+  // Start-of-word numbers, mirroring CrosswordGrid's getCellNumber
+  // (across preferred when both directions start on the same cell).
+  const cellNumbers = new Map<string, number>()
+  for (const clue of numbering.down) {
+    cellNumbers.set(`${clue.row},${clue.col}`, clue.number)
+  }
+  for (const clue of numbering.across) {
+    cellNumbers.set(`${clue.row},${clue.col}`, clue.number)
+  }
+
+  // Size cells so grids up to 19x19 fit the printable width of A4/Letter
+  // (~180mm inside the @page margins), capped at 10mm for small grids.
+  const maxDimension = Math.max(grid.size.rows, grid.size.cols, 1)
+  const cellMm = Math.min(10, Math.round((180 / maxDimension) * 10) / 10)
+
+  const rowsHtml = grid.cells
+    .map((row) => {
+      const cells = row
+        .map((cell) => {
+          if (cell.type === 'block') {
+            return '<td class="block"></td>'
+          }
+          const number = cellNumbers.get(`${cell.row},${cell.col}`)
+          return `<td class="cell">${number ? `<span class="num">${number}</span>` : ''}</td>`
+        })
+        .join('')
+      return `<tr>${cells}</tr>`
+    })
+    .join('\n')
+
+  const clueItems = (clues: CrosswordNumbering['across']) =>
+    clues
+      .map((clue) => `<li value="${clue.number}">${escapeHTML(clue.clue)}</li>`)
+      .join('\n')
+
+  const safeName = escapeHTML(listName)
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${safeName} — crossword</title>
+<style>
+  @page { margin: 12mm; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: Georgia, 'Times New Roman', serif;
+    color: #111;
+    padding: 8mm;
+  }
+  h1 { font-size: 7mm; margin-bottom: 6mm; }
+  h2 { font-size: 5mm; margin-bottom: 2.5mm; }
+  table.grid { border-collapse: collapse; margin-bottom: 8mm; }
+  table.grid td {
+    width: ${cellMm}mm;
+    height: ${cellMm}mm;
+    border: 0.35mm solid #333;
+    position: relative;
+    padding: 0;
+  }
+  td.block {
+    background: #1a1a1a;
+    print-color-adjust: exact;
+    -webkit-print-color-adjust: exact;
+  }
+  td.cell { background: #fff; }
+  td.cell .num {
+    position: absolute;
+    top: 0.5mm;
+    left: 0.7mm;
+    font-size: ${Math.max(2.2, cellMm * 0.3).toFixed(1)}mm;
+    line-height: 1;
+    color: #444;
+  }
+  .clues { display: flex; gap: 12mm; align-items: flex-start; }
+  .clues > section { flex: 1; }
+  .clues ol { list-style-position: inside; font-size: 3.6mm; line-height: 1.6; }
+  @media print {
+    body { padding: 0; }
+  }
+</style>
+</head>
+<body>
+<h1>${safeName}</h1>
+<table class="grid" aria-hidden="true">
+${rowsHtml}
+</table>
+<div class="clues">
+<section>
+<h2>Across</h2>
+<ol>
+${clueItems(numbering.across)}
+</ol>
+</section>
+<section>
+<h2>Down</h2>
+<ol>
+${clueItems(numbering.down)}
+</ol>
+</section>
+</div>
+</body>
+</html>
+`
+}
+
+/**
+ * Open the printable crossword in a new tab and trigger the print dialog.
+ * If the popup is blocked, fall back to downloading the HTML file so the
+ * user can open and print it manually.
+ */
+export function openPrintableCrossword(html: string, fallbackFilename: string) {
+  if (typeof window === 'undefined') return
+
+  const printWindow = window.open('', '_blank')
+  if (!printWindow) {
+    downloadFile(html, fallbackFilename, 'text/html')
+    return
+  }
+
+  printWindow.document.open()
+  printWindow.document.write(html)
+  printWindow.document.close()
+  printWindow.focus()
+  printWindow.print()
+}
+
 export function downloadFile(
   content: string,
   filename: string,


### PR DESCRIPTION
Closes #2

## What
- "Export" on a list now produces a **blank printable crossword** — heading, empty numbered grid (blocks solid, letter cells empty with start-of-word numbers mirroring the on-screen grid), and Across/Down clue lists — opened in a new tab with the print dialog; popup-blocked falls back to downloading the `.html` via the existing `downloadFile` helper. No more raw JSON dump.
- **Never includes answers**: the builder only reads cell structure and clue text (same discipline as `exportPuzzleState`); all user text is HTML-escaped so clue content cannot inject markup.
- Data path: the existing owner-scoped `GET /api/v1/lists/[id]/puzzles` endpoint (auth + `topic:{userId}` scoping) — most recent puzzle is exported. The raw JSON/CSV export helpers and `/lists/:id/export` remain untouched for data interchange.
- No generated puzzle yet → friendly error banner ("Generate a puzzle first — this list doesn't have one yet."), no download.
- Print CSS sized in mm so grids up to 19×19 fit A4/Letter; `print-color-adjust: exact` keeps blocks solid.

## Tests (200 passing at branch time)
- Printable HTML: correct across/down clue numbers/texts and numbered cells; **zero answer letters** (airtight: answers built from letters absent from every clue text); block vs letter cells distinct; single-word grid safe; `<script>` in a clue renders escaped; popup-blocked fallback downloads.
- Route: 401, cross-user 404 scoping, newest-first ordering on the puzzles endpoint.
- Page: export with no puzzle → error, no download; with puzzle → printable written and printed, no answers present.

Docs: `docs/import-export-flow.md`, `docs/specs/CROSSWISE_SPEC.md`, new `docs/uat/UAT_CW-2.md`. Choice point (export targets the most recent puzzle) is documented in the spec/flow docs — flagging for the decision log if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)