### PR TITLE
feat(solve): segmented clue tabs with counts, preset filters, and clue flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to SemVer.
 - Topics can now be deleted from the topics page, with a confirmation dialog that warns all lists, puzzles, and solve progress under the topic are permanently removed (#15)
 - Puzzle generation now grows the grid (15→17→19) when a list doesn't fit, accepts partial puzzles instead of failing outright, and the solve screen discloses any words that didn't fit with a dismissible notice (#99)
 
+### Added
+- The clue panel gained progress-aware Across/Down tabs with solved counts, preset filters (Unsolved, Flagged, Errors) that compose with search, and per-clue flags that persist with your solve progress (#13)
+
 ### Changed
 - Generating a new puzzle now shows a contextual overlay over the grid (with the list name and an accessible progress announcement) instead of replacing the whole screen with a spinner (#14)
 - The solve grid now shows a two-layer highlight — a soft band across the selected clue and a stronger accent plus ring on the active cell — with an accessible high-contrast focus ring, replacing the single hard-coded yellow highlight (#12)

--- a/docs/solve-state-flow.md
+++ b/docs/solve-state-flow.md
@@ -105,3 +105,14 @@ flowchart TD
 - The overlay clears in `finally` — success navigates to the new puzzle, and a
   failed generation restores the previous grid with the error banner; the grid
   is never left blocked.
+
+## Clue Tabs, Filters, and Flags (#13)
+- Across/Down is a semantic tab control (role=tablist/tab/tabpanel, roving
+  tabindex, arrow-key switching) showing live solved/total counts per direction
+  (tabular numerals). Counts and filters derive from the shared
+  `src/lib/clue-status.ts` helpers — the same source as the per-clue badges.
+- Preset filters (All / Unsolved / Flagged / Errors) compose with the search
+  input; the active chip is marked by a check mark and weight, not colour alone.
+- `SolveState.flaggedClues` (optional, keyed `direction-number`) stores flags;
+  `toggleClueFlag` persists through the normal autosave path so flags survive
+  reload and sync like any other solve state.

--- a/src/app/solve/solveState.ts
+++ b/src/app/solve/solveState.ts
@@ -20,6 +20,7 @@ export const normalizeSolveState = (raw: RemoteSolveState | null | undefined): S
   lastSaved: raw?.lastSaved,
   lockedCells: raw?.lockedCells ?? {},
   revision: typeof raw?.revision === 'number' ? raw.revision : undefined,
+  flaggedClues: raw?.flaggedClues ?? {},
 })
 
 const getLastSavedTimestamp = (state: SolveState | null | undefined) => {

--- a/src/components/ClueList.tsx
+++ b/src/components/ClueList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 
+import { clueFlagKey, clueHasError, getClueStatus } from '@/lib/clue-status'
 import { useAppStore } from '@/lib/store'
 import { cn } from '@/lib/utils'
 import { ClueEntry, SolveState } from '@/types/crossword'
@@ -19,6 +20,15 @@ const statusMap = {
   empty: 'text-muted-foreground',
 } as const
 
+type ClueFilter = 'all' | 'unsolved' | 'flagged' | 'errors'
+
+const FILTERS: Array<{ id: ClueFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'unsolved', label: 'Unsolved' },
+  { id: 'flagged', label: 'Flagged' },
+  { id: 'errors', label: 'Errors' },
+]
+
 export default function ClueList({
   clues,
   direction,
@@ -27,42 +37,42 @@ export default function ClueList({
   variant = 'card',
 }: ClueListProps) {
   const [searchQuery, setSearchQuery] = useState('')
-  const { selectClue, selectCell } = useAppStore()
+  const [activeFilter, setActiveFilter] = useState<ClueFilter>('all')
+  const { selectClue, selectCell, toggleClueFlag } = useAppStore()
 
   const handleClueClick = (clue: ClueEntry) => {
     selectClue(direction, clue.number)
     selectCell(clue.row, clue.col)
   }
 
-  const filteredClues = clues.filter((clue) =>
-    clue.clue.toLowerCase().includes(searchQuery.toLowerCase()),
+  const matchesFilter = (clue: ClueEntry): boolean => {
+    switch (activeFilter) {
+      case 'unsolved':
+        // Everything not fully correct: empty, partial, and unchecked-filled.
+        return getClueStatus(clue, direction, solveState) !== 'complete'
+      case 'flagged':
+        return Boolean(solveState?.flaggedClues?.[clueFlagKey(direction, clue.number)])
+      case 'errors':
+        return clueHasError(clue, direction, solveState)
+      default:
+        return true
+    }
+  }
+
+  // Filters compose with the search input (#13).
+  const filteredClues = clues.filter(
+    (clue) => clue.clue.toLowerCase().includes(searchQuery.toLowerCase()) && matchesFilter(clue),
   )
 
-  const getClueStatus = (clue: ClueEntry) => {
-    if (!solveState) return 'empty'
-
-    let filledCount = 0
-    let correctCount = 0
-
-    for (let i = 0; i < clue.length; i++) {
-      const row = direction === 'down' ? clue.row + i : clue.row
-      const col = direction === 'across' ? clue.col + i : clue.col
-      const cellKey = `${row},${col}`
-
-      if (solveState.filledCells[cellKey]) {
-        filledCount++
-
-        if (solveState.checkResults?.[cellKey]) {
-          correctCount++
-        }
-      }
-    }
-
-    if (correctCount === clue.length) return 'complete'
-    if (filledCount === clue.length) return 'filled'
-    if (filledCount > 0) return 'partial'
-    return 'empty'
-  }
+  const emptyMessage = searchQuery
+    ? 'No clues match your search.'
+    : activeFilter === 'flagged'
+      ? 'No flagged clues yet — use the flag on a clue to mark it for later.'
+      : activeFilter === 'errors'
+        ? 'No checked errors — nice work.'
+        : activeFilter === 'unsolved'
+          ? 'Everything here is solved!'
+          : 'No clues available for this direction.'
 
   return (
     <div
@@ -77,7 +87,7 @@ export default function ClueList({
           <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             {direction} clues
           </h3>
-          <span className="text-xs text-muted-foreground">{clues.length} total</span>
+          <span className="text-xs tabular-nums text-muted-foreground">{clues.length} total</span>
         </div>
         <input
           type="text"
@@ -86,44 +96,97 @@ export default function ClueList({
           onChange={(e) => setSearchQuery(e.target.value)}
           className="mt-3 w-full rounded-full border border-input bg-white px-4 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
         />
+        <div
+          className="mt-3 flex flex-wrap gap-2"
+          role="group"
+          aria-label="Filter clues"
+        >
+          {FILTERS.map((filter) => {
+            const isActive = activeFilter === filter.id
+            return (
+              <button
+                key={filter.id}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => setActiveFilter(filter.id)}
+                className={cn(
+                  'rounded-full border px-3 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60',
+                  // Active state indicated by more than colour: check mark,
+                  // weight, and border treatment (UI standard 4.4).
+                  isActive
+                    ? 'border-primary bg-primary/10 font-semibold text-primary'
+                    : 'border-border/70 text-muted-foreground hover:border-border hover:text-foreground',
+                )}
+              >
+                {isActive ? '✓ ' : ''}
+                {filter.label}
+              </button>
+            )
+          })}
+        </div>
       </div>
 
       <div className="flex-1 overflow-y-auto px-3 py-4">
         {filteredClues.length === 0 ? (
           <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-6 text-center text-sm text-muted-foreground">
-            {searchQuery ? 'No clues match your search.' : 'No clues available for this direction.'}
+            {emptyMessage}
           </div>
         ) : (
           <div className="space-y-2">
             {filteredClues.map((clue) => {
               const isSelected =
                 selectedClue?.direction === direction && selectedClue?.number === clue.number
-              const status = getClueStatus(clue)
+              const status = getClueStatus(clue, direction, solveState)
+              const isFlagged = Boolean(
+                solveState?.flaggedClues?.[clueFlagKey(direction, clue.number)],
+              )
 
               return (
-                <button
+                <div
                   key={`${direction}-${clue.number}`}
-                  onClick={() => handleClueClick(clue)}
                   className={cn(
-                    'w-full rounded-xl border border-transparent px-4 py-3 text-left transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60',
+                    'flex w-full items-start gap-1 rounded-xl border border-transparent transition-all duration-150',
                     isSelected
                       ? 'border-primary/40 bg-primary/10 shadow-sm'
                       : 'hover:border-border/80 hover:bg-muted/40',
                   )}
                 >
-                  <div className="flex items-center gap-3">
-                    <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted text-sm font-semibold text-foreground">
-                      {clue.number}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <p className="text-sm font-medium text-foreground">{clue.clue}</p>
-                      <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
-                        <span>{clue.length} letters</span>
-                        <span className={statusMap[status]}>Status: {status}</span>
+                  <button
+                    onClick={() => handleClueClick(clue)}
+                    className="min-w-0 flex-1 rounded-xl px-4 py-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold tabular-nums text-foreground">
+                        {clue.number}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-medium text-foreground">{clue.clue}</p>
+                        <div className="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
+                          <span className="tabular-nums">{clue.length} letters</span>
+                          <span className={statusMap[status]}>Status: {status}</span>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </button>
+                  </button>
+                  <button
+                    type="button"
+                    aria-pressed={isFlagged}
+                    aria-label={
+                      isFlagged
+                        ? `Remove flag from ${direction} ${clue.number}`
+                        : `Flag ${direction} ${clue.number} for later`
+                    }
+                    onClick={() => toggleClueFlag(direction, clue.number)}
+                    className={cn(
+                      'mr-2 mt-3 shrink-0 rounded-full p-1.5 text-sm leading-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60',
+                      isFlagged
+                        ? 'text-amber-500 hover:text-amber-600'
+                        : 'text-muted-foreground/40 hover:text-muted-foreground',
+                    )}
+                  >
+                    ⚑
+                  </button>
+                </div>
               )
             })}
           </div>

--- a/src/components/SolveSurface.tsx
+++ b/src/components/SolveSurface.tsx
@@ -1,3 +1,6 @@
+import { useRef } from 'react'
+
+import { countSolvedClues } from '@/lib/clue-status'
 import { cn } from '@/lib/utils'
 import type { CrosswordGrid as CrosswordGridType, CrosswordNumbering, SolveState } from '@/types/crossword'
 import ClueList from './ClueList'
@@ -24,6 +27,10 @@ export default function SolveSurface({
   isGenerating = false,
   generatingMessage = 'Generating a new puzzle…',
 }: SolveSurfaceProps) {
+  const tabRefs = useRef<Record<'across' | 'down', HTMLButtonElement | null>>({
+    across: null,
+    down: null,
+  })
   const selected = solveState.selectedClue
   const selectedEntry = selected
     ? numbering[selected.direction].find((clue) => clue.number === selected.number)
@@ -100,31 +107,60 @@ export default function SolveSurface({
         </div>
 
         <div className="flex w-full flex-col gap-4 lg:border-l lg:border-border/60 lg:pl-6">
-          <div className="flex rounded-full border border-border/70 bg-muted/60 p-1 text-sm font-medium">
-            <button
-              onClick={() => onSelectTab('across')}
-              className={cn(
-                'flex-1 rounded-full px-4 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60',
-                selectedTab === 'across'
-                  ? 'bg-card text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-            >
-              Across
-            </button>
-            <button
-              onClick={() => onSelectTab('down')}
-              className={cn(
-                'flex-1 rounded-full px-4 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60',
-                selectedTab === 'down'
-                  ? 'bg-card text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground',
-              )}
-            >
-              Down
-            </button>
+          <div
+            role="tablist"
+            aria-label="Clue direction"
+            className="flex rounded-full border border-border/70 bg-muted/60 p-1 text-sm font-medium"
+            onKeyDown={(event) => {
+              // Roving tabs (#13): arrow keys move and activate per the ARIA
+              // tabs pattern; the inactive tab is not in the page tab order.
+              if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+              event.preventDefault()
+              const next = selectedTab === 'across' ? 'down' : 'across'
+              onSelectTab(next)
+              tabRefs.current[next]?.focus()
+            }}
+          >
+            {(['across', 'down'] as const).map((direction) => {
+              const solved = countSolvedClues(numbering[direction], direction, solveState)
+              const total = numbering[direction].length
+              const isActive = selectedTab === direction
+              return (
+                <button
+                  key={direction}
+                  ref={(node) => {
+                    tabRefs.current[direction] = node
+                  }}
+                  role="tab"
+                  id={`clue-tab-${direction}`}
+                  aria-selected={isActive}
+                  aria-controls={`clue-panel-${direction}`}
+                  tabIndex={isActive ? 0 : -1}
+                  onClick={() => onSelectTab(direction)}
+                  className={cn(
+                    'flex flex-1 items-center justify-center gap-2 rounded-full px-4 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60',
+                    isActive
+                      ? 'bg-card font-semibold text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {direction === 'across' ? 'Across' : 'Down'}
+                  <span
+                    className="tabular-nums text-xs text-muted-foreground"
+                    aria-label={`${solved} of ${total} solved`}
+                  >
+                    {solved}/{total}
+                  </span>
+                </button>
+              )
+            })}
           </div>
-          <div className="flex-1">
+          <div
+            className="flex-1"
+            role="tabpanel"
+            id={`clue-panel-${selectedTab}`}
+            aria-labelledby={`clue-tab-${selectedTab}`}
+          >
             <ClueList
               clues={numbering[selectedTab]}
               direction={selectedTab}

--- a/src/components/__tests__/ClueList.test.tsx
+++ b/src/components/__tests__/ClueList.test.tsx
@@ -9,10 +9,13 @@ import type { ClueEntry, SolveState } from '@/types/crossword'
 const selectClueMock = vi.fn()
 const selectCellMock = vi.fn()
 
+const toggleClueFlagMock = vi.fn()
+
 vi.mock('@/lib/store', () => ({
   useAppStore: () => ({
     selectClue: selectClueMock,
     selectCell: selectCellMock,
+    toggleClueFlag: toggleClueFlagMock,
   }),
 }))
 
@@ -82,5 +85,76 @@ describe('ClueList', () => {
 
     expect(selectClueMock).toHaveBeenCalledWith('across', 1)
     expect(selectCellMock).toHaveBeenCalledWith(0, 0)
+  })
+})
+
+describe('ClueList preset filters (#13)', () => {
+  // CAT (clue 1) is fully correct; DOG (clue 5) is partial with one checked error.
+  const filterState: SolveState = {
+    filledCells: { '0,0': 'C', '0,1': 'A', '0,2': 'T', '1,0': 'D', '1,1': 'O' },
+    checkResults: { '0,0': true, '0,1': true, '0,2': true, '1,0': false },
+    startTime: new Date(),
+    flaggedClues: { 'across-5': true },
+  }
+
+  const renderList = () =>
+    render(
+      <ClueList clues={clues} direction="across" solveState={filterState} />,
+    )
+
+  it('Unsolved hides fully-correct clues', async () => {
+    renderList()
+    await userEvent.click(screen.getByRole('button', { name: 'Unsolved' }))
+
+    expect(screen.queryByText('Furry friend')).not.toBeInTheDocument()
+    expect(screen.getByText('Loyal companion')).toBeInTheDocument()
+  })
+
+  it('Errors shows only clues with a false check result', async () => {
+    renderList()
+    await userEvent.click(screen.getByRole('button', { name: 'Errors' }))
+
+    expect(screen.queryByText('Furry friend')).not.toBeInTheDocument()
+    expect(screen.getByText('Loyal companion')).toBeInTheDocument()
+  })
+
+  it('Flagged shows only flagged clues and the flag toggle calls the store action', async () => {
+    renderList()
+    await userEvent.click(screen.getByRole('button', { name: 'Flagged' }))
+
+    expect(screen.queryByText('Furry friend')).not.toBeInTheDocument()
+    expect(screen.getByText('Loyal companion')).toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Remove flag from across 5' }),
+    )
+    expect(toggleClueFlagMock).toHaveBeenCalledWith('across', 5)
+  })
+
+  it('filters compose with search and show a clear empty state when nothing matches', async () => {
+    renderList()
+    await userEvent.click(screen.getByRole('button', { name: 'Errors' }))
+    await userEvent.type(screen.getByPlaceholderText('Search clues'), 'furry')
+
+    expect(screen.queryByText('Loyal companion')).not.toBeInTheDocument()
+    expect(screen.getByText('No clues match your search.')).toBeInTheDocument()
+  })
+
+  it('applying a filter makes no network calls and mutates nothing', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    renderList()
+    await userEvent.click(screen.getByRole('button', { name: 'Unsolved' }))
+    expect(fetchSpy).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+
+  it('active filter is indicated by more than colour (check mark + aria-pressed)', async () => {
+    renderList()
+    const unsolved = screen.getByRole('button', { name: 'Unsolved' })
+    await userEvent.click(unsolved)
+
+    expect(unsolved.getAttribute('aria-pressed')).toBe('true')
+    expect(unsolved.textContent).toContain('✓')
   })
 })

--- a/src/components/__tests__/SolveSurface.test.tsx
+++ b/src/components/__tests__/SolveSurface.test.tsx
@@ -158,3 +158,61 @@ describe('SolveSurface generation overlay (#14)', () => {
     expect(selectCellMock).toHaveBeenCalledWith(0, 0)
   })
 })
+
+describe('SolveSurface segmented tabs (#13)', () => {
+  const renderTabs = (onSelectTab = vi.fn(), state: SolveState = solveState) => {
+    const utils = render(
+      <SolveSurface
+        grid={grid}
+        numbering={numbering}
+        solveState={state}
+        selectedTab="across"
+        onSelectTab={onSelectTab}
+      />,
+    )
+    return { onSelectTab, ...utils }
+  }
+
+  it('renders semantic tabs with solved/total counts', () => {
+    // Across 1 ("HI" at 0,0-0,1) fully correct; across 2 untouched.
+    const state: SolveState = {
+      ...solveState,
+      filledCells: { '0,0': 'H', '0,1': 'I' },
+      checkResults: { '0,0': true, '0,1': true },
+    }
+    const { getAllByRole } = renderTabs(vi.fn(), state)
+
+    const tabs = getAllByRole('tab')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0].textContent).toContain('Across')
+    expect(tabs[0].textContent).toContain('1/2')
+    expect(tabs[1].textContent).toContain('Down')
+    expect(tabs[1].textContent).toContain('0/1')
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true')
+    expect(tabs[1].getAttribute('aria-selected')).toBe('false')
+    // Roving focus: only the active tab is in the tab order.
+    expect(tabs[0].getAttribute('tabindex')).toBe('0')
+    expect(tabs[1].getAttribute('tabindex')).toBe('-1')
+  })
+
+  it('clicking a tab switches the direction', () => {
+    const { onSelectTab, getAllByRole } = renderTabs()
+    fireEvent.click(getAllByRole('tab')[1])
+    expect(onSelectTab).toHaveBeenCalledWith('down')
+  })
+
+  it('arrow keys move between tabs (ARIA tabs pattern)', () => {
+    const { onSelectTab, getByRole } = renderTabs()
+    fireEvent.keyDown(getByRole('tablist'), { key: 'ArrowRight' })
+    expect(onSelectTab).toHaveBeenCalledWith('down')
+  })
+
+  it('switching tabs makes no network calls', () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const { getAllByRole } = renderTabs()
+    fireEvent.click(getAllByRole('tab')[1])
+    expect(fetchSpy).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/lib/__tests__/store.test.ts
+++ b/src/lib/__tests__/store.test.ts
@@ -123,6 +123,20 @@ describe('useAppStore crossword interactions', () => {
     expect(updatedState.isWon).toBe(true)
   })
 
+  it('toggleClueFlag adds/removes a flag and it survives a save/reload round-trip (#13)', () => {
+    const store = primeStoreForPuzzle()
+
+    store.toggleClueFlag('across', 1)
+    expect(useAppStore.getState().solveState?.flaggedClues?.['across-1']).toBe(true)
+
+    // Persisted via the normal autosave path: reload from localStorage keeps it.
+    const saved = JSON.parse(localStorage.getItem('crosswise_solve_puzzle-1') ?? '{}')
+    expect(saved.flaggedClues?.['across-1']).toBe(true)
+
+    store.toggleClueFlag('across', 1)
+    expect(useAppStore.getState().solveState?.flaggedClues?.['across-1']).toBeUndefined()
+  })
+
   it('persists solve state snapshots when cells change', () => {
     const store = primeStoreForPuzzle()
 

--- a/src/lib/clue-status.ts
+++ b/src/lib/clue-status.ts
@@ -1,0 +1,67 @@
+import type { ClueEntry, SolveState } from '@/types/crossword'
+
+export type ClueStatus = 'complete' | 'filled' | 'partial' | 'empty'
+
+// Single source of truth for a clue's solve status (#13): tab counts and clue
+// filters must agree with the per-clue status badges, so they all derive from
+// this helper rather than reimplementing the walk.
+export function getClueStatus(
+  clue: ClueEntry,
+  direction: 'across' | 'down',
+  solveState?: SolveState | null,
+): ClueStatus {
+  if (!solveState) return 'empty'
+
+  let filledCount = 0
+  let correctCount = 0
+
+  for (let i = 0; i < clue.length; i++) {
+    const row = direction === 'down' ? clue.row + i : clue.row
+    const col = direction === 'across' ? clue.col + i : clue.col
+    const cellKey = `${row},${col}`
+
+    if (solveState.filledCells[cellKey]) {
+      filledCount++
+
+      if (solveState.checkResults?.[cellKey]) {
+        correctCount++
+      }
+    }
+  }
+
+  if (correctCount === clue.length) return 'complete'
+  if (filledCount === clue.length) return 'filled'
+  if (filledCount > 0) return 'partial'
+  return 'empty'
+}
+
+// True when at least one of the clue's cells has been checked and is wrong.
+export function clueHasError(
+  clue: ClueEntry,
+  direction: 'across' | 'down',
+  solveState?: SolveState | null,
+): boolean {
+  if (!solveState?.checkResults) return false
+
+  for (let i = 0; i < clue.length; i++) {
+    const row = direction === 'down' ? clue.row + i : clue.row
+    const col = direction === 'across' ? clue.col + i : clue.col
+    if (solveState.checkResults[`${row},${col}`] === false) {
+      return true
+    }
+  }
+  return false
+}
+
+export function countSolvedClues(
+  clues: ClueEntry[],
+  direction: 'across' | 'down',
+  solveState?: SolveState | null,
+): number {
+  return clues.filter((clue) => getClueStatus(clue, direction, solveState) === 'complete').length
+}
+
+// Key for a clue in SolveState.flaggedClues.
+export function clueFlagKey(direction: 'across' | 'down', number: number): string {
+  return `${direction}-${number}`
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -53,6 +53,7 @@ interface AppState {
   updateCell: (row: number, col: number, letter: string) => void
   selectCell: (row: number, col: number) => void
   selectClue: (direction: 'across' | 'down', number: number) => void
+  toggleClueFlag: (direction: 'across' | 'down', number: number) => void
   clearCell: (row: number, col: number) => void
   clearWord: (direction: 'across' | 'down', number: number) => void
   checkSolution: (mode: 'letter' | 'word' | 'puzzle') => void
@@ -333,6 +334,29 @@ export const useAppStore = create<AppState>()(
         }
 
         set({ solveState: updatedState })
+      },
+
+      // Flag/unflag a clue for later (#13). Persisted through the normal
+      // autosave path so flags survive reload (autosave non-negotiable).
+      toggleClueFlag: (direction, number) => {
+        const state = get()
+        if (!state.solveState || !state.currentPuzzle) return
+
+        const key = `${direction}-${number}`
+        const flaggedClues = { ...(state.solveState.flaggedClues ?? {}) }
+        if (flaggedClues[key]) {
+          delete flaggedClues[key]
+        } else {
+          flaggedClues[key] = true
+        }
+
+        const updatedState = {
+          ...state.solveState,
+          flaggedClues,
+        }
+
+        set({ solveState: updatedState })
+        autosaveManager.forceSave(state.currentPuzzle.id, updatedState)
       },
 
       clearCell: (row, col) => {

--- a/src/types/crossword.ts
+++ b/src/types/crossword.ts
@@ -88,6 +88,9 @@ export interface SolveState {
   // save so reconciliation no longer depends on cross-device wall clocks.
   // Optional for back-compat with states saved before the field existed.
   revision?: number
+  // Clues the solver flagged for later (#13), keyed "direction-number".
+  // Optional for back-compat; persists through the normal autosave path.
+  flaggedClues?: Record<string, boolean>
 }
 
 // UI types


### PR DESCRIPTION
Closes #13

## What
- **Segmented tabs**: Across/Down is now a real ARIA tab control (`role=tablist/tab/tabpanel`, `aria-selected`, roving tabindex, ArrowLeft/ArrowRight switching) with live solved/total counts per direction in tabular numerals — solvers see progress at a glance.
- **Shared status source**: new `src/lib/clue-status.ts` (`getClueStatus`, `clueHasError`, `countSolvedClues`) — tab counts, filters, and the per-clue status badges all derive from the same walk, so they can't disagree. `ClueList`'s inline copy removed.
- **Preset filters**: All / Unsolved / Flagged / Errors chips compose with the existing search; each filter has a tailored empty-state message; the active chip is indicated by a check mark + weight + `aria-pressed`, not colour alone.
- **Clue flags**: per-clue flag toggle (`aria-pressed`, labelled). `SolveState.flaggedClues` (optional, keyed `direction-number`, back-compat default `{}`) persists through the normal autosave path — flags survive reload and ride the #84 sync like any other solve state. New `toggleClueFlag` store action.
- Sentence-case labels; tabs/chips fully keyboard-operable with visible focus; switching tabs or filters makes no network calls and mutates nothing.

## Tests (219 passing; 11 new)
- SolveSurface: tabs with correct counts/semantics/roving tabindex; click and arrow-key switching; no network calls.
- ClueList: Unsolved hides fully-correct; Errors shows only false-check clues; Flagged filters and the toggle calls the store; filter+search compose with empty state; active-chip affordance beyond colour.
- Store: `toggleClueFlag` round-trips through localStorage and untoggles cleanly.

Docs: `docs/solve-state-flow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)