### PR TITLE
feat(auth): add forgot password / account recovery flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to SemVer.
 ## [Unreleased]
 
 ### Added
+- Forgot-password account recovery: request a reset link from the login page and set a new password via a single-use, 30-minute emailed token; all sessions are revoked on reset (email delivery is a dev stub until a provider is chosen, ADR-008) (#7)
 - Topics can now be deleted from the topics page, with a confirmation dialog that warns all lists, puzzles, and solve progress under the topic are permanently removed (#15)
 - Puzzle generation now grows the grid (15→17→19) when a list doesn't fit, accepts partial puzzles instead of failing outright, and the solve screen discloses any words that didn't fit with a dismissible notice (#99)
 

--- a/docs/architecture/decisions/ADR-008-password-recovery-email-seam.md
+++ b/docs/architecture/decisions/ADR-008-password-recovery-email-seam.md
@@ -1,0 +1,68 @@
+# ADR-008: Password recovery + email delivery seam
+
+**Status:** Proposed
+**Date:** 2026-07-13
+**Deciders:** dragondad22
+**Related ADRs:** ADR-001 (per-user data ownership — a reset token is bound to its user)
+
+## 1. Context
+
+CrossWise had no account-recovery path (#7): a user who forgot their password was
+permanently locked out of their topics, lists, puzzles, and solve history. Recovery is
+an ASVS-sensitive surface (CW-C-006): it must not enable account enumeration, tokens
+must be strong, single-use, and time-limited, and a reset must invalidate existing
+sessions (CLAUDE.md non-negotiable: sessions revoked server-side).
+
+Recovery also requires delivering a reset link by email — and the repo has **no email
+infrastructure at all**. Choosing a provider (Resend, SES, Postmark, …) introduces a
+third-party processor of user email addresses, which matters for the privacy posture
+(CW-C-002, and the Decision 1 minors posture). That choice should not be made
+implicitly inside a feature PR.
+
+## 2. Decision
+
+**Recovery design**
+
+- New `PasswordResetToken` table: `userId` (cascade to `users`), unique `tokenHash`,
+  `expiresAt`, nullable `consumedAt`. Only a **SHA-256 hash** of the token is stored;
+  the raw 32-byte (`randomBytes(32)`) token exists solely in the emailed link.
+- Tokens are single-use (atomic conditional consume) and expire after **30 minutes**.
+- `POST /api/v1/auth/password/forgot` returns one generic success body regardless of
+  whether the email matches an account (no enumeration via status, body, or errors).
+- `POST /api/v1/auth/password/reset` takes `{ token, newPassword }`; the token is the
+  credential. On success the password is bcrypt-hashed via the existing `hashPassword`
+  (salt rounds 12) and **all** of the user's sessions are revoked.
+- Interim brute-force guard: a per-instance in-memory fixed-window limiter
+  (5 requests / 15 min per client key) on both endpoints, explicitly a placeholder
+  until real rate limiting lands (#89).
+
+**Email delivery seam**
+
+- All email sending goes through one narrow interface: `sendPasswordResetEmail(to,
+  resetUrl)` in `src/lib/email.ts`. No third-party email SDK is added.
+- The default implementation is a dev stub: outside production it logs the reset link
+  to the server console (so the flow is testable end-to-end locally); in production it
+  no-ops with a `console.warn` that delivery is not configured, and never logs the
+  recipient or the link.
+- Selecting a real provider is a **deferred decision**: when made, it updates this ADR
+  (or supersedes it) and is surfaced to the compliance register as a new processor of
+  personal data (CW-C-002).
+
+## 3. Consequences
+
+**Good**
+- Recovery ships with the security properties fixed (hashed-at-rest, single-use,
+  time-limited, enumeration-proof, sessions revoked) independent of any provider choice.
+- The provider decision stays explicit and compliance-visible instead of being buried
+  in a feature PR; swapping the stub for a provider touches one module.
+- No raw secret at rest: a database leak does not expose usable reset links.
+
+**Trade-offs**
+- Until a provider is chosen, production users cannot actually receive reset emails —
+  the endpoint behaves correctly but delivery silently no-ops (with a server warning).
+  Shipping a provider is the required follow-up before recovery is usable in prod.
+- The interim in-memory limiter only bounds abuse per warm serverless instance; real
+  limiting is deferred to #89.
+- SHA-256 (not bcrypt) for token hashing is deliberate: the input is a 256-bit random
+  value, so brute-forcing the hash is infeasible and a fast hash keeps lookup O(1) by
+  unique index.

--- a/docs/architecture/decisions/ADR_INDEX.md
+++ b/docs/architecture/decisions/ADR_INDEX.md
@@ -2,7 +2,7 @@
 
 CrossWise
 
-**Updated:** 2026-07-10
+**Updated:** 2026-07-13
 
 This index tracks all architectural decisions for CrossWise:
 - Completed ADRs
@@ -21,6 +21,7 @@ Status labels: **Proposed** | **Accepted** | **Rejected** | **Superseded**
 | ADR-001 | Per-user ownership of topics, lists, and puzzles | Accepted | `ADR-001-user-data-ownership-model.md` |
 | ADR-002 | Production DB migration & backfill strategy | Accepted | `ADR-002-db-migration-strategy.md` |
 | ADR-006 | Puzzle generation seed contract | Proposed | `ADR-006-puzzle-seed-contract.md` |
+| ADR-008 | Password recovery + email delivery seam | Proposed | `ADR-008-password-recovery-email-seam.md` |
 
 ---
 

--- a/docs/auth-session-flow.md
+++ b/docs/auth-session-flow.md
@@ -8,6 +8,8 @@ Explain how users authenticate, how sessions are created, and how the client hyd
 - `POST /api/v1/auth/register`
 - `GET /api/v1/auth/session`
 - `POST /api/v1/auth/logout`
+- `POST /api/v1/auth/password/forgot`
+- `POST /api/v1/auth/password/reset`
 
 ## Primary Actors
 - Client UI (Next.js)
@@ -36,19 +38,72 @@ flowchart TD
     HYDRATE --> NOTE[Subsequent requests send cookie automatically]
 ```
 
+## Forgot Password / Account Recovery (#7, ADR-008)
+
+1. User follows "Forgot password?" from `/login` to `/forgot-password` and submits their email.
+2. `POST /api/v1/auth/password/forgot` validates the email and **always** returns the same
+   generic success — whether or not an account exists (no account enumeration via status,
+   body, or errors).
+3. If the email matches a user, the API creates a `PasswordResetToken` row: a
+   `randomBytes(32)` token whose **SHA-256 hash** is stored (never the raw token),
+   expiring after **30 minutes**. The raw token exists only in the reset link.
+4. The reset link (`/reset-password?token=...`) is handed to the email delivery seam
+   (`src/lib/email.ts`, ADR-008). Until a provider is configured: dev logs the link to the
+   server console; production no-ops with a warning.
+5. The user opens `/reset-password?token=...` and submits a new password
+   (same policy as registration: 8–100 chars).
+6. `POST /api/v1/auth/password/reset` hashes the incoming token, then consumes it
+   atomically — it must exist, be unexpired, and never used. Any failure returns one
+   generic "invalid or expired" error.
+7. On success the new password is bcrypt-hashed (`hashPassword`, salt rounds 12) and
+   **all of the user's sessions are revoked** (`deleteSessionsForUser`), so a stolen
+   pre-reset session cannot persist. The user signs in again with the new password.
+
+Token lifecycle: created (hash at rest, 30-min expiry) → consumed exactly once
+(`consumedAt` set atomically) or expired → expired rows are cleaned up opportunistically
+on the next token creation. Both endpoints carry an interim per-instance rate limit
+(5 requests / 15 min per client) until real rate limiting lands (#89).
+
+```mermaid
+flowchart TD
+    F[/forgot-password form/] -->|"POST password/forgot { email }"| FA[Forgot API]
+    FA -->|Lookup email| DB2[(users)]
+    DB2 -->|Found| TOK["Create PasswordResetToken (SHA-256 hash, 30 min)"]
+    TOK --> MAIL["Email seam: send reset link (ADR-008)"]
+    DB2 -->|Not found| GEN
+    MAIL --> GEN["Same generic 200 either way"]
+    R[/reset-password?token=... form/] -->|"POST password/reset { token, newPassword }"| RA[Reset API]
+    RA -->|Hash token + consume atomically| PRT[(password_reset_tokens)]
+    PRT -- invalid/expired/used --> RERR["400 generic error"]
+    PRT -- valid --> UPD["bcrypt-hash new password"]
+    UPD --> REVOKE["Revoke ALL user sessions"]
+    REVOKE --> DONE["200 — user signs in again"]
+```
+
 ## Data Artifacts
 - Cookie: `crosswise_session`
 - Session row: `sessions` table
 - User row: `users` table
+- Password reset token row: `password_reset_tokens` table (`token_hash` unique,
+  `expires_at`, `consumed_at`; cascade-deleted with the user)
 
 ## Failure Modes
 - Invalid credentials -> 401 with error message.
 - Missing/expired session -> `{ user: null }` from `GET /api/v1/auth/session`.
 - Logout -> session deleted and cookie cleared.
+- Forgot password with unknown email -> identical generic success (no enumeration).
+- Reset with forged/expired/already-used token -> 400 with one generic message.
+- Too many forgot/reset requests -> 429 (interim limiter; real rate limiting is #89).
 
 ## Key Files
 - `src/app/api/v1/auth/login/route.ts`
 - `src/app/api/v1/auth/register/route.ts`
 - `src/app/api/v1/auth/session/route.ts`
 - `src/app/api/v1/auth/logout/route.ts`
+- `src/app/api/v1/auth/password/forgot/route.ts`
+- `src/app/api/v1/auth/password/reset/route.ts`
+- `src/lib/auth.ts` (reset-token helpers, session revocation)
+- `src/lib/email.ts` (email delivery seam, ADR-008)
+- `src/app/forgot-password/page.tsx`
+- `src/app/reset-password/page.tsx`
 - `src/app/layout.tsx`

--- a/docs/uat/UAT_CW-7.md
+++ b/docs/uat/UAT_CW-7.md
@@ -1,0 +1,39 @@
+# UAT — CW-7: Forgot Password / account recovery flow
+
+- Work Item: CW-7 (#7)
+- Feature / Workflow: Password recovery — forgot-password request + token-based reset
+- Environment: local / preview
+
+## Behavior Under Test
+
+A user who forgot their password can request a reset link by email and use it to set
+a new password. The flow must not reveal whether an email has an account, tokens must
+be single-use and expire after 30 minutes (stored hashed, never plaintext), and a
+successful reset must revoke every existing session for that user. Email delivery is
+a dev stub until a provider is chosen (ADR-008): locally the reset link is printed to
+the server console; in production delivery no-ops with a server warning.
+
+## Acceptance Scenarios
+
+| # | Scenario | Steps | Expected |
+|---|---|---|---|
+| 1 | Happy path | From `/login` click "Forgot password?", submit a registered email, open the logged reset link, enter a new password (≥8 chars), sign in with it | Generic confirmation after request; reset page shows success with a link to sign in; login works with the new password only |
+| 2 | No account enumeration | Submit a registered email, then an unregistered one, to `/forgot-password` (or `POST /api/v1/auth/password/forgot`) | Identical generic response (status + body) both times; no hint whether the account exists |
+| 3 | Single-use token | Complete a reset, then open the same link and try again | Second attempt fails with the generic "invalid or expired" error; password unchanged |
+| 4 | Expired token | Use a reset link more than 30 minutes after requesting it | Generic "invalid or expired" error; user can request a new link |
+| 5 | Forged/malformed token | Open `/reset-password?token=garbage` and submit; also `/reset-password` with no token | Generic error; no indication whether any account or token matched |
+| 6 | Sessions revoked on reset | Sign in on browser A, complete a password reset from browser B, then act in browser A | Browser A's session is invalid (signed out); only the new password signs in |
+| 7 | Password policy | Attempt a reset with a 7-character password | 400 / inline error citing the 8-character minimum; token not consumed |
+| 8 | Hashed at rest | After a request + reset, inspect `password_reset_tokens` and `users` rows and server logs | Only `token_hash` (SHA-256) stored — raw token appears nowhere; `password_hash` is bcrypt; no plaintext password or raw token in logs (dev-stub reset link log excepted, non-production only) |
+| 9 | Brute-force guard | Send 6 rapid requests to either endpoint from one client | 6th request returns 429 (interim limiter; full rate limiting tracked in #89) |
+| 10 | Accessibility | Operate both forms with keyboard only | All fields labeled and focusable, visible focus, submit works via Enter; success/error states announced (role="status"/"alert") |
+
+## Notes
+
+- Recovery design + email delivery seam recorded in ADR-008
+  (`docs/architecture/decisions/ADR-008-password-recovery-email-seam.md`).
+- Token helpers live in `src/lib/auth.ts` (`createPasswordResetToken`,
+  `consumePasswordResetToken`, `deleteSessionsForUser`); request shapes in
+  `src/lib/validation.ts` (`ForgotPasswordSchema`, `ResetPasswordSchema`).
+- Production email delivery is intentionally not configured yet — choosing a
+  provider is the follow-up decision gated by ADR-008.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "crosswise",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "crosswise",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/prisma/migrations/20260713152557_add_password_reset_token/migration.sql
+++ b/prisma/migrations/20260713152557_add_password_reset_token/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "password_reset_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "consumed_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "password_reset_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "password_reset_tokens_token_hash_key" ON "password_reset_tokens"("token_hash");
+
+-- AddForeignKey
+ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,6 +99,7 @@ model User {
   topics       Topic[]
   solves       Solve[]
   sessions     Session[]
+  passwordResetTokens PasswordResetToken[]
 
   @@map("users")
 }
@@ -113,6 +114,19 @@ model Session {
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("sessions")
+}
+
+model PasswordResetToken {
+  id         String    @id @default(cuid())
+  userId     String    @map("user_id")
+  tokenHash  String    @unique @map("token_hash")
+  expiresAt  DateTime  @map("expires_at")
+  consumedAt DateTime? @map("consumed_at")
+  createdAt  DateTime  @default(now()) @map("created_at")
+
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("password_reset_tokens")
 }
 
 enum ListSource {

--- a/src/app/api/v1/auth/__tests__/password-forgot.test.ts
+++ b/src/app/api/v1/auth/__tests__/password-forgot.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import { POST } from '../password/forgot/route'
+import { __resetRateLimit } from '@/lib/rate-limit'
+
+const { userFindUnique } = vi.hoisted(() => ({
+  userFindUnique: vi.fn(),
+}))
+
+const createPasswordResetTokenMock = vi.hoisted(() => vi.fn())
+const sendPasswordResetEmailMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      findUnique: userFindUnique,
+    },
+  },
+}))
+
+vi.mock('@/lib/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth')>('@/lib/auth')
+  return {
+    ...actual,
+    createPasswordResetToken: createPasswordResetTokenMock,
+  }
+})
+
+vi.mock('@/lib/email', () => ({
+  sendPasswordResetEmail: sendPasswordResetEmailMock,
+}))
+
+function forgotRequest(body: unknown, ip = '203.0.113.7') {
+  return new NextRequest('http://localhost/api/v1/auth/password/forgot', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': ip },
+  })
+}
+
+describe('POST /api/v1/auth/password/forgot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetRateLimit()
+    createPasswordResetTokenMock.mockResolvedValue({
+      token: 'raw-reset-token-abc123',
+      expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+    })
+    sendPasswordResetEmailMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    __resetRateLimit()
+  })
+
+  it('creates a reset token and delivers the link for a known email', async () => {
+    userFindUnique.mockResolvedValueOnce({ id: 'user-1', email: 'known@example.com' })
+
+    const response = await POST(forgotRequest({ email: 'Known@Example.com' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.success).toBe(true)
+    expect(userFindUnique).toHaveBeenCalledWith({ where: { email: 'known@example.com' } })
+    expect(createPasswordResetTokenMock).toHaveBeenCalledWith('user-1')
+    expect(sendPasswordResetEmailMock).toHaveBeenCalledWith(
+      'known@example.com',
+      'http://localhost/reset-password?token=raw-reset-token-abc123',
+    )
+  })
+
+  it('returns a byte-identical response for unknown and known emails (no enumeration)', async () => {
+    userFindUnique.mockResolvedValueOnce({ id: 'user-1', email: 'known@example.com' })
+    const knownResponse = await POST(forgotRequest({ email: 'known@example.com' }, '203.0.113.1'))
+    const knownBody = await knownResponse.text()
+
+    userFindUnique.mockResolvedValueOnce(null)
+    const unknownResponse = await POST(
+      forgotRequest({ email: 'nobody@example.com' }, '203.0.113.2'),
+    )
+    const unknownBody = await unknownResponse.text()
+
+    expect(unknownResponse.status).toBe(knownResponse.status)
+    expect(unknownBody).toBe(knownBody)
+  })
+
+  it('never creates a token or sends email for an unknown email', async () => {
+    userFindUnique.mockResolvedValueOnce(null)
+
+    const response = await POST(forgotRequest({ email: 'nobody@example.com' }))
+
+    expect(response.status).toBe(200)
+    expect(createPasswordResetTokenMock).not.toHaveBeenCalled()
+    expect(sendPasswordResetEmailMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed email with 400', async () => {
+    const response = await POST(forgotRequest({ email: 'not-an-email' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.success).toBe(false)
+    expect(userFindUnique).not.toHaveBeenCalled()
+  })
+
+  it('still returns the generic success when token creation fails (no leak via errors)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    userFindUnique.mockResolvedValueOnce({ id: 'user-1', email: 'known@example.com' })
+    createPasswordResetTokenMock.mockRejectedValueOnce(new Error('db down'))
+
+    const response = await POST(forgotRequest({ email: 'known@example.com' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.success).toBe(true)
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('rate limits repeated requests from the same client (interim guard, #89)', async () => {
+    userFindUnique.mockResolvedValue(null)
+
+    for (let i = 0; i < 5; i += 1) {
+      const response = await POST(forgotRequest({ email: 'nobody@example.com' }, '198.51.100.9'))
+      expect(response.status).toBe(200)
+    }
+
+    const blocked = await POST(forgotRequest({ email: 'nobody@example.com' }, '198.51.100.9'))
+    const payload = await blocked.json()
+
+    expect(blocked.status).toBe(429)
+    expect(payload.success).toBe(false)
+  })
+})

--- a/src/app/api/v1/auth/__tests__/password-reset.test.ts
+++ b/src/app/api/v1/auth/__tests__/password-reset.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import { POST } from '../password/reset/route'
+import { __resetRateLimit } from '@/lib/rate-limit'
+
+const { userUpdate } = vi.hoisted(() => ({
+  userUpdate: vi.fn(),
+}))
+
+const consumePasswordResetTokenMock = vi.hoisted(() => vi.fn())
+const deleteSessionsForUserMock = vi.hoisted(() => vi.fn())
+const hashPasswordMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    user: {
+      update: userUpdate,
+    },
+  },
+}))
+
+vi.mock('@/lib/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth')>('@/lib/auth')
+  return {
+    ...actual,
+    consumePasswordResetToken: consumePasswordResetTokenMock,
+    deleteSessionsForUser: deleteSessionsForUserMock,
+    hashPassword: hashPasswordMock,
+  }
+})
+
+function resetRequest(body: unknown, ip = '203.0.113.50') {
+  return new NextRequest('http://localhost/api/v1/auth/password/reset', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': ip },
+  })
+}
+
+describe('POST /api/v1/auth/password/reset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetRateLimit()
+    hashPasswordMock.mockResolvedValue('bcrypt-hashed-password')
+    deleteSessionsForUserMock.mockResolvedValue({ count: 2 })
+    userUpdate.mockResolvedValue({ id: 'user-1' })
+  })
+
+  afterEach(() => {
+    __resetRateLimit()
+  })
+
+  it('resets the password (bcrypt-hashed) and revokes all sessions for a valid token', async () => {
+    consumePasswordResetTokenMock.mockResolvedValueOnce('user-1')
+
+    const response = await POST(
+      resetRequest({ token: 'valid-raw-token', newPassword: 'brandnewpass' }),
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.success).toBe(true)
+    expect(consumePasswordResetTokenMock).toHaveBeenCalledWith('valid-raw-token')
+    expect(hashPasswordMock).toHaveBeenCalledWith('brandnewpass')
+    expect(userUpdate).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { passwordHash: 'bcrypt-hashed-password' },
+    })
+    expect(deleteSessionsForUserMock).toHaveBeenCalledWith('user-1')
+
+    // The plaintext password must never be written to the database.
+    expect(JSON.stringify(userUpdate.mock.calls[0][0])).not.toContain('brandnewpass')
+  })
+
+  it('rejects an invalid/forged token with a generic error and no side effects', async () => {
+    consumePasswordResetTokenMock.mockResolvedValueOnce(null)
+
+    const response = await POST(
+      resetRequest({ token: 'forged-token', newPassword: 'brandnewpass' }),
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.success).toBe(false)
+    expect(payload.error.message).toBe(
+      'This reset link is invalid or has expired. Please request a new one.',
+    )
+    expect(userUpdate).not.toHaveBeenCalled()
+    expect(deleteSessionsForUserMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects expired and already-used tokens with the same generic error', async () => {
+    // consumePasswordResetToken returns null for expired and consumed tokens alike;
+    // the route must not distinguish the cases in its response.
+    consumePasswordResetTokenMock.mockResolvedValue(null)
+
+    const expired = await POST(
+      resetRequest({ token: 'expired-token', newPassword: 'brandnewpass' }, '203.0.113.51'),
+    )
+    const reused = await POST(
+      resetRequest({ token: 'used-token', newPassword: 'brandnewpass' }, '203.0.113.52'),
+    )
+
+    expect(expired.status).toBe(400)
+    expect(reused.status).toBe(400)
+    expect(await expired.text()).toBe(await reused.text())
+  })
+
+  it('cannot be reused: the second reset with the same token fails', async () => {
+    consumePasswordResetTokenMock.mockResolvedValueOnce('user-1').mockResolvedValueOnce(null)
+
+    const first = await POST(
+      resetRequest({ token: 'single-use-token', newPassword: 'brandnewpass' }, '203.0.113.53'),
+    )
+    const second = await POST(
+      resetRequest({ token: 'single-use-token', newPassword: 'differentpass' }, '203.0.113.54'),
+    )
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(400)
+    expect(userUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it("only ever resets the token owner's password (user A token cannot touch user B)", async () => {
+    consumePasswordResetTokenMock.mockResolvedValueOnce('user-a')
+
+    const response = await POST(
+      resetRequest({ token: 'user-a-token', newPassword: 'brandnewpass' }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(userUpdate).toHaveBeenCalledTimes(1)
+    expect(userUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'user-a' } }),
+    )
+  })
+
+  it('rejects a policy-violating password before consuming the token', async () => {
+    const response = await POST(resetRequest({ token: 'valid-raw-token', newPassword: 'short' }))
+    const payload = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(payload.success).toBe(false)
+    expect(consumePasswordResetTokenMock).not.toHaveBeenCalled()
+    expect(userUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing/empty token generically', async () => {
+    const response = await POST(resetRequest({ token: '', newPassword: 'brandnewpass' }))
+
+    expect(response.status).toBe(400)
+    expect(consumePasswordResetTokenMock).not.toHaveBeenCalled()
+    expect(userUpdate).not.toHaveBeenCalled()
+  })
+
+  it('rate limits repeated attempts from the same client (interim guard, #89)', async () => {
+    consumePasswordResetTokenMock.mockResolvedValue(null)
+
+    for (let i = 0; i < 5; i += 1) {
+      const response = await POST(
+        resetRequest({ token: 'guess', newPassword: 'brandnewpass' }, '198.51.100.20'),
+      )
+      expect(response.status).toBe(400)
+    }
+
+    const blocked = await POST(
+      resetRequest({ token: 'guess', newPassword: 'brandnewpass' }, '198.51.100.20'),
+    )
+
+    expect(blocked.status).toBe(429)
+  })
+})

--- a/src/app/api/v1/auth/password/forgot/route.ts
+++ b/src/app/api/v1/auth/password/forgot/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ZodError } from 'zod'
+
+import { prisma } from '@/lib/db'
+import { ForgotPasswordSchema } from '@/lib/validation'
+import { createPasswordResetToken } from '@/lib/auth'
+import { sendPasswordResetEmail } from '@/lib/email'
+import { checkRateLimit, clientKeyFromHeaders } from '@/lib/rate-limit'
+
+// The one and only success payload. Known and unknown emails MUST return this
+// exact body and status so account existence cannot be enumerated (#7).
+const GENERIC_MESSAGE =
+  'If an account exists for that email, a password reset link has been sent.'
+
+function genericResponse() {
+  return NextResponse.json({ success: true, data: { message: GENERIC_MESSAGE } })
+}
+
+export async function POST(request: NextRequest) {
+  // Interim per-instance limiter — replaced by the real rate-limiting layer (#89).
+  if (!checkRateLimit(`password-forgot:${clientKeyFromHeaders(request.headers)}`)) {
+    return NextResponse.json(
+      { success: false, error: { message: 'Too many requests. Please try again later.' } },
+      { status: 429 },
+    )
+  }
+
+  try {
+    const body = await request.json()
+    const parsed = ForgotPasswordSchema.parse(body)
+
+    const user = await prisma.user.findUnique({
+      where: { email: parsed.email },
+    })
+
+    if (user) {
+      const { token } = await createPasswordResetToken(user.id)
+      const resetUrl = `${request.nextUrl.origin}/reset-password?token=${token}`
+      await sendPasswordResetEmail(user.email, resetUrl)
+    }
+
+    return genericResponse()
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { success: false, error: { message: 'Valid email required' } },
+        { status: 400 },
+      )
+    }
+
+    // Internal failures (token creation, delivery) can only occur for existing
+    // accounts — returning the generic success keeps errors from leaking
+    // account existence. The failure is still logged server-side (no PII).
+    console.error('Failed to process password reset request:', error)
+    return genericResponse()
+  }
+}

--- a/src/app/api/v1/auth/password/reset/route.ts
+++ b/src/app/api/v1/auth/password/reset/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ZodError } from 'zod'
+
+import { prisma } from '@/lib/db'
+import { ResetPasswordSchema } from '@/lib/validation'
+import { consumePasswordResetToken, deleteSessionsForUser, hashPassword } from '@/lib/auth'
+import { checkRateLimit, clientKeyFromHeaders } from '@/lib/rate-limit'
+
+// Generic rejection for every invalid-token case (missing, forged, expired,
+// already used) — never reveals whether any account or token matched (#7).
+const INVALID_TOKEN_MESSAGE =
+  'This reset link is invalid or has expired. Please request a new one.'
+
+export async function POST(request: NextRequest) {
+  // Interim per-instance limiter — replaced by the real rate-limiting layer (#89).
+  if (!checkRateLimit(`password-reset:${clientKeyFromHeaders(request.headers)}`)) {
+    return NextResponse.json(
+      { success: false, error: { message: 'Too many requests. Please try again later.' } },
+      { status: 429 },
+    )
+  }
+
+  try {
+    const body = await request.json()
+    const parsed = ResetPasswordSchema.parse(body)
+
+    // The token is the credential: consuming it atomically enforces single-use
+    // and binds the reset to the user the token was issued for.
+    const userId = await consumePasswordResetToken(parsed.token)
+
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: { message: INVALID_TOKEN_MESSAGE } },
+        { status: 400 },
+      )
+    }
+
+    const passwordHash = await hashPassword(parsed.newPassword)
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { passwordHash },
+    })
+
+    // Non-negotiable: a stolen pre-reset session must not survive the reset.
+    await deleteSessionsForUser(userId)
+
+    return NextResponse.json({
+      success: true,
+      data: { message: 'Your password has been reset. You can now sign in.' },
+    })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { success: false, error: { message: 'Invalid reset data', details: error.issues } },
+        { status: 400 },
+      )
+    }
+
+    console.error('Failed to reset password:', error)
+    return NextResponse.json(
+      { success: false, error: { message: 'Password reset failed' } },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import Link from 'next/link'
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      const response = await fetch('/api/v1/auth/password/forgot', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email }),
+      })
+
+      const result = await response.json()
+
+      if (response.ok && result.success) {
+        setSubmitted(true)
+      } else {
+        setError(result.error?.message || 'Unable to process the request. Please try again.')
+      }
+    } catch (err) {
+      setError('Network error. Please try again.')
+      console.error('Forgot password request failed:', err)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-72px)] items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4 py-8">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg">
+        <h1 className="mb-2 text-center text-2xl font-semibold text-gray-800">
+          Forgot your password?
+        </h1>
+        <p className="mb-6 text-center text-sm text-gray-500">
+          Enter your email and we&apos;ll send you a link to reset it.
+        </p>
+
+        {submitted ? (
+          <div role="status">
+            <div className="mb-4 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+              If an account exists for that email, a password reset link has been sent. Check your
+              inbox — the link expires after 30 minutes.
+            </div>
+            <p className="text-center text-sm text-gray-500">
+              <Link href="/login" className="font-medium text-blue-600 hover:text-blue-700">
+                Back to sign in
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <>
+            {error && (
+              <div
+                role="alert"
+                className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              >
+                {error}
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
+                  Email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  required
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="you@example.com"
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full rounded-md bg-blue-600 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? 'Sending…' : 'Send reset link'}
+              </button>
+            </form>
+
+            <p className="mt-6 text-center text-sm text-gray-500">
+              Remembered it?{' '}
+              <Link href="/login" className="font-medium text-blue-600 hover:text-blue-700">
+                Back to sign in
+              </Link>
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -101,9 +101,17 @@ export default function LoginPage() {
           </div>
 
           <div>
-            <label htmlFor="password" className="mb-1 block text-sm font-medium text-gray-700">
-              Password
-            </label>
+            <div className="mb-1 flex items-center justify-between">
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                Password
+              </label>
+              <Link
+                href="/forgot-password"
+                className="text-sm font-medium text-blue-600 hover:text-blue-700"
+              >
+                Forgot password?
+              </Link>
+            </div>
             <input
               id="password"
               type="password"

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+
+export default function ResetPasswordPage() {
+  const searchParams = useSearchParams()
+  const token = searchParams.get('token') ?? ''
+
+  const [newPassword, setNewPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [succeeded, setSucceeded] = useState(false)
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      const response = await fetch('/api/v1/auth/password/reset', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ token, newPassword }),
+      })
+
+      const result = await response.json()
+
+      if (response.ok && result.success) {
+        setSucceeded(true)
+      } else {
+        setError(result.error?.message || 'Unable to reset the password. Please try again.')
+      }
+    } catch (err) {
+      setError('Network error. Please try again.')
+      console.error('Password reset failed:', err)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-[calc(100vh-72px)] items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4 py-8">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-lg">
+        <h1 className="mb-2 text-center text-2xl font-semibold text-gray-800">
+          Choose a new password
+        </h1>
+        <p className="mb-6 text-center text-sm text-gray-500">
+          Enter a new password for your CrossWise account.
+        </p>
+
+        {succeeded ? (
+          <div role="status">
+            <div className="mb-4 rounded border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+              Your password has been reset. Sign in with your new password to continue.
+            </div>
+            <p className="text-center text-sm text-gray-500">
+              <Link href="/login" className="font-medium text-blue-600 hover:text-blue-700">
+                Go to sign in
+              </Link>
+            </p>
+          </div>
+        ) : !token ? (
+          <div role="alert">
+            <div className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+              This reset link is missing its token. Request a new link and open it directly from
+              the email.
+            </div>
+            <p className="text-center text-sm text-gray-500">
+              <Link
+                href="/forgot-password"
+                className="font-medium text-blue-600 hover:text-blue-700"
+              >
+                Request a new reset link
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <>
+            {error && (
+              <div
+                role="alert"
+                className="mb-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+              >
+                {error}{' '}
+                <Link href="/forgot-password" className="font-medium underline">
+                  Request a new link
+                </Link>
+              </div>
+            )}
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label
+                  htmlFor="new-password"
+                  className="mb-1 block text-sm font-medium text-gray-700"
+                >
+                  New password
+                </label>
+                <input
+                  id="new-password"
+                  type="password"
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  value={newPassword}
+                  onChange={(event) => setNewPassword(event.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="At least 8 characters"
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full rounded-md bg-blue-600 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? 'Resetting…' : 'Reset password'}
+              </button>
+            </form>
+
+            <p className="mt-6 text-center text-sm text-gray-500">
+              <Link href="/login" className="font-medium text-blue-600 hover:text-blue-700">
+                Back to sign in
+              </Link>
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto'
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 
 import {
@@ -8,6 +9,9 @@ import {
   getSessionForToken,
   deleteSessionByToken,
   cleanupExpiredSessions,
+  createPasswordResetToken,
+  consumePasswordResetToken,
+  deleteSessionsForUser,
   __resetSessionCleanupState,
   SESSION_COOKIE_NAME,
 } from '../auth'
@@ -19,6 +23,12 @@ const prismaMocks = vi.hoisted(() => ({
     delete: vi.fn(),
     deleteMany: vi.fn(),
     update: vi.fn(),
+  },
+  passwordResetToken: {
+    create: vi.fn(),
+    findUnique: vi.fn(),
+    updateMany: vi.fn(),
+    deleteMany: vi.fn(),
   },
 }))
 
@@ -55,6 +65,8 @@ describe('auth helpers', () => {
     randomBytesMock.mockImplementation(() => Buffer.from('default-token', 'utf-8'))
     prismaMocks.session.deleteMany.mockResolvedValue({ count: 0 })
     prismaMocks.session.update.mockResolvedValue(undefined)
+    prismaMocks.passwordResetToken.deleteMany.mockResolvedValue({ count: 0 })
+    prismaMocks.passwordResetToken.updateMany.mockResolvedValue({ count: 1 })
     __resetSessionCleanupState()
   })
 
@@ -200,6 +212,125 @@ describe('auth helpers', () => {
 
   it('exposes the session cookie constant for reuse', () => {
     expect(SESSION_COOKIE_NAME).toBe('crosswise_session')
+  })
+
+  describe('password reset tokens (#7)', () => {
+    it('creates a reset token, storing only a SHA-256 hash with a 30-minute expiry', async () => {
+      randomBytesMock.mockReturnValueOnce(Buffer.from('reset-secret', 'utf-8'))
+      prismaMocks.passwordResetToken.create.mockResolvedValueOnce(undefined)
+
+      const { token, expiresAt } = await createPasswordResetToken('user-1')
+
+      expect(randomBytesMock).toHaveBeenCalledWith(32)
+      expect(token).toBe(Buffer.from('reset-secret', 'utf-8').toString('hex'))
+      expect(expiresAt.toISOString()).toBe('2024-01-01T00:30:00.000Z')
+
+      const expectedHash = createHash('sha256').update(token).digest('hex')
+      expect(prismaMocks.passwordResetToken.create).toHaveBeenCalledWith({
+        data: {
+          userId: 'user-1',
+          tokenHash: expectedHash,
+          expiresAt,
+        },
+      })
+
+      // The raw token must never reach storage — only its hash.
+      const storedData = prismaMocks.passwordResetToken.create.mock.calls[0][0].data
+      expect(storedData.tokenHash).not.toBe(token)
+      expect(JSON.stringify(storedData)).not.toContain(token)
+    })
+
+    it('opportunistically cleans up expired reset tokens on create', async () => {
+      prismaMocks.passwordResetToken.create.mockResolvedValueOnce(undefined)
+
+      await createPasswordResetToken('user-1')
+
+      expect(prismaMocks.passwordResetToken.deleteMany).toHaveBeenCalledWith({
+        where: { expiresAt: { lt: new Date('2024-01-01T00:00:00.000Z') } },
+      })
+    })
+
+    it('consumes a valid token by hash and returns its owning userId', async () => {
+      prismaMocks.passwordResetToken.findUnique.mockResolvedValueOnce({
+        id: 'prt-1',
+        userId: 'user-1',
+        consumedAt: null,
+        expiresAt: new Date('2024-01-01T00:15:00Z'),
+      })
+
+      const result = await consumePasswordResetToken('raw-token')
+
+      expect(prismaMocks.passwordResetToken.findUnique).toHaveBeenCalledWith({
+        where: { tokenHash: createHash('sha256').update('raw-token').digest('hex') },
+      })
+      expect(prismaMocks.passwordResetToken.updateMany).toHaveBeenCalledWith({
+        where: { id: 'prt-1', consumedAt: null },
+        data: { consumedAt: new Date('2024-01-01T00:00:00.000Z') },
+      })
+      expect(result).toBe('user-1')
+    })
+
+    it('rejects an expired token without consuming it', async () => {
+      prismaMocks.passwordResetToken.findUnique.mockResolvedValueOnce({
+        id: 'prt-1',
+        userId: 'user-1',
+        consumedAt: null,
+        expiresAt: new Date('2023-12-31T23:59:59Z'),
+      })
+
+      const result = await consumePasswordResetToken('raw-token')
+
+      expect(result).toBeNull()
+      expect(prismaMocks.passwordResetToken.updateMany).not.toHaveBeenCalled()
+    })
+
+    it('rejects an already-consumed token (single-use)', async () => {
+      prismaMocks.passwordResetToken.findUnique.mockResolvedValueOnce({
+        id: 'prt-1',
+        userId: 'user-1',
+        consumedAt: new Date('2024-01-01T00:05:00Z'),
+        expiresAt: new Date('2024-01-01T00:15:00Z'),
+      })
+
+      const result = await consumePasswordResetToken('raw-token')
+
+      expect(result).toBeNull()
+      expect(prismaMocks.passwordResetToken.updateMany).not.toHaveBeenCalled()
+    })
+
+    it('rejects an unknown/forged token', async () => {
+      prismaMocks.passwordResetToken.findUnique.mockResolvedValueOnce(null)
+
+      const result = await consumePasswordResetToken('forged-token')
+
+      expect(result).toBeNull()
+      expect(prismaMocks.passwordResetToken.updateMany).not.toHaveBeenCalled()
+    })
+
+    it('rejects a token that lost the atomic consumption race', async () => {
+      prismaMocks.passwordResetToken.findUnique.mockResolvedValueOnce({
+        id: 'prt-1',
+        userId: 'user-1',
+        consumedAt: null,
+        expiresAt: new Date('2024-01-01T00:15:00Z'),
+      })
+      prismaMocks.passwordResetToken.updateMany.mockResolvedValueOnce({ count: 0 })
+
+      const result = await consumePasswordResetToken('raw-token')
+
+      expect(result).toBeNull()
+    })
+
+    it('revokes every session for a user', async () => {
+      prismaMocks.session.deleteMany.mockResolvedValueOnce({ count: 3 })
+
+      const result = await deleteSessionsForUser('user-1')
+
+      expect(prismaMocks.session.deleteMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+      })
+      expect(result).toEqual({ count: 3 })
+    })
   })
 
   it('exports a cleanup helper that deletes expired sessions', async () => {

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -5,6 +5,8 @@ import {
   normalizeAnswer,
   validateAnswerFormat,
   ImportListSchema,
+  ForgotPasswordSchema,
+  ResetPasswordSchema,
 } from '../validation'
 
 describe('validation helpers', () => {
@@ -174,5 +176,42 @@ describe('validation helpers', () => {
       items: [{ ...base.items[0], difficulty: 6 }, ...base.items.slice(1)],
     }
     expect(validateListJSON(bad).success).toBe(false)
+  })
+
+  describe('password recovery schemas (#7)', () => {
+    it('normalizes forgot-password emails to lowercase', () => {
+      const parsed = ForgotPasswordSchema.parse({ email: 'User@Example.COM' })
+      expect(parsed.email).toBe('user@example.com')
+    })
+
+    it('rejects malformed forgot-password emails', () => {
+      expect(ForgotPasswordSchema.safeParse({ email: 'not-an-email' }).success).toBe(false)
+      expect(ForgotPasswordSchema.safeParse({}).success).toBe(false)
+    })
+
+    it('accepts a reset request with a token and a policy-compliant password', () => {
+      const parsed = ResetPasswordSchema.parse({
+        token: 'a'.repeat(64),
+        newPassword: 'longenough',
+      })
+      expect(parsed.token).toBe('a'.repeat(64))
+      expect(parsed.newPassword).toBe('longenough')
+    })
+
+    it('enforces the register password policy on reset (min 8, max 100)', () => {
+      expect(
+        ResetPasswordSchema.safeParse({ token: 'tok', newPassword: 'short7c' }).success,
+      ).toBe(false)
+      expect(
+        ResetPasswordSchema.safeParse({ token: 'tok', newPassword: 'x'.repeat(101) }).success,
+      ).toBe(false)
+    })
+
+    it('requires a non-empty token', () => {
+      expect(
+        ResetPasswordSchema.safeParse({ token: '', newPassword: 'longenough' }).success,
+      ).toBe(false)
+      expect(ResetPasswordSchema.safeParse({ newPassword: 'longenough' }).success).toBe(false)
+    })
   })
 })

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto'
+import { createHash, randomBytes } from 'crypto'
 import bcrypt from 'bcryptjs'
 
 import { prisma } from './db'
@@ -8,6 +8,7 @@ export const SESSION_COOKIE_NAME = 'crosswise_session'
 const SESSION_DURATION_MS = 1000 * 60 * 60 * 24 * 7 // 7 days
 const SESSION_REFRESH_THRESHOLD_MS = 1000 * 60 * 60 * 24 // 24 hours
 const SESSION_CLEANUP_INTERVAL_MS = 1000 * 60 * 60 // 1 hour
+const PASSWORD_RESET_TOKEN_DURATION_MS = 1000 * 60 * 30 // 30 minutes
 
 let lastCleanupRun = 0
 
@@ -114,4 +115,67 @@ async function maybeCleanupExpiredSessions() {
 
 export function __resetSessionCleanupState() {
   lastCleanupRun = 0
+}
+
+// --- Password reset tokens (#7) ---
+//
+// Reset tokens are higher-risk than session tokens (they arrive over email and grant
+// a password change), so only a SHA-256 hash is ever stored — the raw token exists
+// solely in the reset link delivered to the user. Never store or log the raw token.
+
+function hashPasswordResetToken(rawToken: string) {
+  return createHash('sha256').update(rawToken).digest('hex')
+}
+
+export async function createPasswordResetToken(userId: string) {
+  const rawToken = randomBytes(32).toString('hex')
+  const expiresAt = new Date(Date.now() + PASSWORD_RESET_TOKEN_DURATION_MS)
+
+  // Opportunistic cleanup of expired rows, mirroring the session cleanup approach.
+  await prisma.passwordResetToken
+    .deleteMany({ where: { expiresAt: { lt: new Date() } } })
+    .catch((error) => {
+      console.error('Failed to cleanup expired password reset tokens:', error)
+    })
+
+  await prisma.passwordResetToken.create({
+    data: {
+      userId,
+      tokenHash: hashPasswordResetToken(rawToken),
+      expiresAt,
+    },
+  })
+
+  return { token: rawToken, expiresAt }
+}
+
+/**
+ * Validates a raw reset token (exists, not expired, not consumed) and marks it
+ * consumed. Returns the owning userId, or null for any invalid token — callers
+ * must not distinguish why (no account/token enumeration).
+ */
+export async function consumePasswordResetToken(rawToken: string): Promise<string | null> {
+  const tokenHash = hashPasswordResetToken(rawToken)
+
+  const record = await prisma.passwordResetToken.findUnique({ where: { tokenHash } })
+
+  if (!record) return null
+  if (record.consumedAt) return null
+  if (record.expiresAt < new Date()) return null
+
+  // Conditional update makes consumption atomic: two concurrent requests with the
+  // same token cannot both succeed (single-use enforced at the database).
+  const consumed = await prisma.passwordResetToken.updateMany({
+    where: { id: record.id, consumedAt: null },
+    data: { consumedAt: new Date() },
+  })
+
+  if (consumed.count === 0) return null
+
+  return record.userId
+}
+
+/** Revokes every session for a user (e.g. after a password reset). */
+export async function deleteSessionsForUser(userId: string) {
+  return prisma.session.deleteMany({ where: { userId } })
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,25 @@
+/**
+ * Email delivery seam (ADR-008).
+ *
+ * CrossWise has no email provider today. This module is the single, narrow
+ * interface every email-sending feature must go through, so a real provider can
+ * be wired in later without touching callers. Do NOT import a third-party email
+ * SDK here without recording that decision (see ADR-008).
+ *
+ * The default implementation is a development stub:
+ * - Non-production: logs the reset link to the server console so the flow can be
+ *   exercised end-to-end locally. This is the only place a raw reset link may be
+ *   logged, and only outside production.
+ * - Production: no-ops with a warning that delivery is not configured. It never
+ *   logs the recipient or the link (the link embeds the raw token).
+ */
+export async function sendPasswordResetEmail(to: string, resetUrl: string): Promise<void> {
+  if (process.env.NODE_ENV === 'production') {
+    console.warn(
+      '[email] Password reset requested but no email delivery provider is configured (ADR-008); email not sent.',
+    )
+    return
+  }
+
+  console.info(`[email:dev-stub] Password reset link for ${to}: ${resetUrl}`)
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,60 @@
+/**
+ * INTERIM in-memory fixed-window rate limiter for the password recovery
+ * endpoints (#7). Deliberately cheap: per-process memory, fixed window, no
+ * distributed state — on serverless it only bounds abuse per warm instance.
+ *
+ * #89 (real rate limiting) REPLACES this module. Do not extend it to other
+ * endpoints; wire them to the #89 solution instead.
+ */
+
+const WINDOW_MS = 15 * 60 * 1000 // 15 minutes
+const MAX_REQUESTS_PER_WINDOW = 5
+const MAX_TRACKED_KEYS = 10_000
+
+interface WindowEntry {
+  windowStart: number
+  count: number
+}
+
+const buckets = new Map<string, WindowEntry>()
+
+/**
+ * Returns true when the request identified by `key` is allowed, false when the
+ * fixed window's budget is exhausted.
+ */
+export function checkRateLimit(
+  key: string,
+  max: number = MAX_REQUESTS_PER_WINDOW,
+  windowMs: number = WINDOW_MS,
+): boolean {
+  const now = Date.now()
+
+  // Bound memory: drop stale windows once the map grows large.
+  if (buckets.size >= MAX_TRACKED_KEYS) {
+    buckets.forEach((entry, k) => {
+      if (now - entry.windowStart >= windowMs) buckets.delete(k)
+    })
+  }
+
+  const entry = buckets.get(key)
+
+  if (!entry || now - entry.windowStart >= windowMs) {
+    buckets.set(key, { windowStart: now, count: 1 })
+    return true
+  }
+
+  entry.count += 1
+  return entry.count <= max
+}
+
+/** Derives a best-effort client key from proxy headers (Vercel sets x-forwarded-for). */
+export function clientKeyFromHeaders(headers: Headers): string {
+  const forwarded = headers.get('x-forwarded-for')
+  if (forwarded) return forwarded.split(',')[0].trim()
+  return headers.get('x-real-ip') ?? 'unknown'
+}
+
+/** Test-only: clears all tracked windows. */
+export function __resetRateLimit() {
+  buckets.clear()
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -145,6 +145,22 @@ export const LoginSchema = z.object({
   password: z.string().min(1, 'Password required'),
 })
 
+export const ForgotPasswordSchema = z.object({
+  email: z
+    .string()
+    .email('Valid email required')
+    .transform((val) => val.toLowerCase()),
+})
+
+export const ResetPasswordSchema = z.object({
+  token: z.string().min(1, 'Reset token required'),
+  // Same password policy as RegisterSchema.
+  newPassword: z
+    .string()
+    .min(8, 'Password must be at least 8 characters')
+    .max(100, 'Password must be at most 100 characters'),
+})
+
 // Validation helper functions
 export function validateListJSON(data: unknown) {
   try {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -23,6 +23,8 @@ import {
   UpdateSolveStateSchema,
   RegisterSchema,
   LoginSchema,
+  ForgotPasswordSchema,
+  ResetPasswordSchema,
 } from '@/lib/validation'
 import type { CrosswordGrid, CrosswordNumbering } from '@/types/crossword'
 
@@ -36,6 +38,8 @@ export type ImportListRequest = z.input<typeof ImportListSchema>
 export type UpdateSolveStateRequest = z.input<typeof UpdateSolveStateSchema>
 export type RegisterRequest = z.input<typeof RegisterSchema>
 export type LoginRequest = z.input<typeof LoginSchema>
+export type ForgotPasswordRequest = z.input<typeof ForgotPasswordSchema>
+export type ResetPasswordRequest = z.input<typeof ResetPasswordSchema>
 
 // --- Response types (no schema yet; declared directly) ---
 


### PR DESCRIPTION
Closes #7

Implements account recovery per the issue; the email-delivery seam decision is recorded as **ADR-008 (status: Proposed — needs human approval)**.

## What
- **Data model**: `PasswordResetToken` (hashed token only — SHA-256 at rest, unique; 30-min expiry; `consumedAt`; cascade from User). Additive migration `20260713152557_add_password_reset_token`.
- **Auth lib**: `createPasswordResetToken` (raw `randomBytes(32)` returned once, never stored/logged; opportunistic expired-row cleanup), `consumePasswordResetToken` (expired/consumed/forged all → null; atomic conditional `updateMany` enforces single-use under races), `deleteSessionsForUser`.
- **Routes**: `POST /api/v1/auth/password/forgot` returns a byte-identical generic success whether or not the email exists (no enumeration via status, body, or error paths); `POST /api/v1/auth/password/reset` consumes the token, bcrypt-hashes via the existing `hashPassword`, and **revokes all of the user's sessions**. One generic 400 for every bad-token case.
- **Rate limiting**: interim in-memory fixed-window limiter (5 req/15 min/IP) on both endpoints, explicitly commented as replaced by #89.
- **Email seam** (`src/lib/email.ts`): no provider exists in the repo — dev logs the reset link, production no-ops with a warning. No third-party SDK. ADR-008 records the seam + the open provider decision.
- **UI**: "Forgot password?" on login; `/forgot-password` and `/reset-password` pages matching the auth pages' styling, with loading/success/error states and announced status regions.
- **Zod-first contract**: `ForgotPasswordSchema`/`ResetPasswordSchema` with types derived in `src/types/api.ts`.

## Tests (215 passing at branch time; 24 new)
Hashed-at-rest; expiry; single-use + reuse rejection; race-lost consumption; **byte-identical enumeration check**; session revocation on reset; token for user A cannot reset user B; forged/malformed tokens; 429s; no plaintext reaches the DB.

Docs: `docs/auth-session-flow.md` (flow + token lifecycle + diagram), ADR-008 + index, `docs/uat/UAT_CW-7.md`, CHANGELOG.

## Needs human attention (also in the session summary)
- The Neon DB in local `.env` was **empty** (no tables/migrations) despite expectations of real data — the migration was applied there harmlessly, but confirm where the real-data DB lives before prod deploy runs `migrate deploy`.
- Production email delivery is a no-op until a provider is chosen (ADR-008).
- Compliance register rows (CW-C-002/CW-C-006) should be updated when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)